### PR TITLE
Tidy up makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ clean:
 create-dirs:
 	mkdir -p test-reports/junit
 
-test: create-dirs
+test-all: create-dirs
 	py.test -v --junitxml=$(PROJECT_DIR)/test-reports/junit/test-pytest.xml
 
 test-without-run-oommf: create-dirs
@@ -33,7 +33,7 @@ test-basic:
 tq:
 	make test-quick
 # Quick tests, also not using OOMMF tests
-test-quick:
+test:
 	cd tests && py.test -v -m "not slow and not run_oommf"
 
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test: create-dirs
 	py.test -v --junitxml=$(PROJECT_DIR)/test-reports/junit/test-pytest.xml
 
 test-without-run-oommf: create-dirs
-	py.test -v --junitxml=$(PROJECT_DIR)/test-reports/junit/test-pytest.xml -m "not run_oommf" --cov=fidimag --cov-report=html
+	py.test -v -m "not run_oommf" --cov=fidimag --cov-report=html --junitxml=$(PROJECT_DIR)/test-reports/junit/test-pytest.xml 
 
 test-basic:
 	cd tests && py.test -v

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,11 @@ clean:
 test:
 	cd tests && py.test -v -m "not slow and not run_oommf"
 
+test2:
+	# like test, but run also outside the 'tests' directory.
+	# Doesn't work on Hans laptop.
+	py.test -v -m "not slow and not run_oommf"
+
 test-all: create-dirs
 	py.test -v --junitxml=$(PROJECT_DIR)/test-reports/junit/test-pytest.xml
 
@@ -40,6 +45,9 @@ test-quick:
 
 test-ipynb: create-dirs
 	cd doc/ipynb && py.test . -v --ipynb --sanitize-with sanitize_file --junitxml=$(PROJECT_DIR)/test-reports/junit/test-ipynb-pytest.xml
+
+test-oommf:
+	py.test -v -m "oommf"
 
 create-dirs:
 	mkdir -p test-reports/junit

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,9 @@ clean:
 # Tests #
 #########
 
-create-dirs:
-	mkdir -p test-reports/junit
+# Quick tests, also not using OOMMF tests
+test:
+	cd tests && py.test -v -m "not slow and not run_oommf"
 
 test-all: create-dirs
 	py.test -v --junitxml=$(PROJECT_DIR)/test-reports/junit/test-pytest.xml
@@ -36,13 +37,13 @@ tq:
 test-quick:
 	$(error This target 'test-quick' has been removed, please update the code calling this)
 
-# Quick tests, also not using OOMMF tests
-test:
-	cd tests && py.test -v -m "not slow and not run_oommf"
-
 
 test-ipynb: create-dirs
 	cd doc/ipynb && py.test . -v --ipynb --sanitize-with sanitize_file --junitxml=$(PROJECT_DIR)/test-reports/junit/test-ipynb-pytest.xml
+
+create-dirs:
+	mkdir -p test-reports/junit
+
 
 #################
 # Documentation #

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,11 @@ test-basic:
 
 # Convenience name for commonly used quick running of tests
 tq:
-	make test-quick
+	$(error This target 'tq' has been removed, please update the code calling this)
+
+test-quick:
+	$(error This target 'test-quick' has been removed, please update the code calling this)
+
 # Quick tests, also not using OOMMF tests
 test:
 	cd tests && py.test -v -m "not slow and not run_oommf"


### PR DESCRIPTION
Tidying up Makefile, in particular make the target 'test' the one that is quick and does not rely on OOMMF.