### PR TITLE
bug fix for setup.py

### DIFF
--- a/bin/install-fftw.sh
+++ b/bin/install-fftw.sh
@@ -30,7 +30,7 @@ download_and_install() {
         tar -xzf ${1}.tar.gz
         cd ${1}
         echo "Configuring "${1}"."
-        ./configure --quiet --enable-shared --prefix=${LIBS_DIR} $3
+        ./configure --quiet --enable-shared --enable-openmp --prefix=${LIBS_DIR}
         echo "Compiling and installing "${1}"."
         {
             make
@@ -41,6 +41,6 @@ download_and_install() {
     fi;
 }
 
-download_and_install ${FFTW} http://www.fftw.org "--enable-openmp --enable-avx"
+download_and_install ${FFTW} http://www.fftw.org
 
 echo "Installation succesful."

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -217,16 +217,18 @@ Notes:
   failed without a working X server).
 
 Install on OS X
-===============
+=================
 
 The inbuilt OS X gcc compiler (actually clang) doesn't have OpenMP support. A workaround is to
 
 - install gcc5 (via homebrew, for example: ``brew install gcc --without-multilib``)
 - set CC environment variable to point to that compiler: ``export CC=gcc-5``
 
+Alternatively, gcc can be installed through ``sudo port install gcc5`` and CC environment 
+variable can be set via ``export CC=gcc-mp-5``
 
-Once this is done, run ``bin/install.sh`` which will compile fftw3 and
-sundials (in a local subdirectory) using this compiler.
+Once this is done, run ``bin/install-fftw.sh`` and ``bin/install-sundials.sh`` which will 
+compile fftw3 and sundials (in a local subdirectory) using this compiler.
 
 Also install pytest (``conda install pytest`` if using conda) and
 ``pyvtk`` via pip (``pip install pyvtk``).

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ if 'icc' in os.environ['CC']:
     com_link.append('-openmp')
 else:
     com_args.append('-fopenmp')
-    com_args.append('-fopenmp')
+    com_link.append('-fopenmp')
 
 
 com_inc = [numpy.get_include(), INCLUDE_DIR]


### PR DESCRIPTION
In my box with ubuntu 16.04 and gcc 5.3.1,  an error occurs in running time:   ImportError: fidimag/extensions/clib.so: undefined symbol: omp_get_thread_num. Interestingly, travis haven't catch this error.