### PR TITLE
Methods for the calculation of the skyrmion number

### DIFF
--- a/fidimag/atomistic/lib/clib.h
+++ b/fidimag/atomistic/lib/clib.h
@@ -78,6 +78,9 @@ void normalise(double *m, int *pins, int n);
 double skyrmion_number(double *spin, double *charge,
                        int nx, int ny, int nz, int *ngbs);
 
+double skyrmion_number_BergLuscher(double *spin, double *charge,
+                                   int nx, int ny, int nz, int *ngbs);
+
 void compute_guiding_center(double *spin, int nx, int ny, int nz, double *res);
 
 void compute_px_py_c(double *spin, int nx, int ny, int nz,

--- a/fidimag/atomistic/lib/clib.pyx
+++ b/fidimag/atomistic/lib/clib.pyx
@@ -12,6 +12,10 @@ cdef extern from "clib.h":
     double skyrmion_number(double *spin, double *charge,
                            int nx, int ny, int nz, int *ngbs)
 
+
+    double skyrmion_number_BergLuscher(double *spin, double *charge,
+                                       int nx, int ny, int nz, int *ngbs)
+
     void compute_guiding_center(double *spin, int nx, int ny, int nz,
                                 double *res)
 
@@ -82,6 +86,15 @@ def compute_skyrmion_number(np.ndarray[double, ndim=1, mode="c"] spin,
                             ):
 
     return skyrmion_number(&spin[0], &charge[0], nx, ny, nz, &ngbs[0,0])
+
+
+def compute_skyrmion_number_BergLuscher(np.ndarray[double, ndim=1, mode="c"] spin,
+                            np.ndarray[double, ndim=1, mode="c"] charge,
+                            nx, ny, nz,
+                            np.ndarray[int, ndim=2, mode="c"] ngbs
+                            ):
+
+    return skyrmion_number_BergLuscher(&spin[0], &charge[0], nx, ny, nz, &ngbs[0,0])
 
 def compute_RxRy(np.ndarray[double, ndim=1, mode="c"] spin,
                             nx, ny, nz):

--- a/fidimag/atomistic/lib/util.c
+++ b/fidimag/atomistic/lib/util.c
@@ -159,6 +159,11 @@ double skyrmion_number(double *spin, double *charge,
 }
 
 double dot(double *a, double *b){
+    /* Dot product for vectors of 3 components, given by arrays a and b.  If
+     * pointers are passed, it uses the first three components starting from
+     * that place in memory, i.e. if we pass &a[2], where a = {0, 1, 2, 3, 4},
+     * the dot product uses {2, 3, 4} as a vector (same for b)
+     */
     double dp = 0;
     int i;
 
@@ -167,6 +172,35 @@ double dot(double *a, double *b){
 }
 
 double compute_BergLuscher_angle(double *s1, double *s2, double *s3){
+
+    /* Compute the spherical angle given by the neighbouring spin 3-vectors s1,
+     * s2 and s3 (these are arrays that can be also passed as pointers; see the
+     * -dot- function). The spherical angle Omega, defined by the
+     *  vectors in a unit sphere, is computed using the imaginary exponential
+     *  defined by Berg and Luscher [Nucl Phys B 190, 412 (1981)]:
+
+     *   exp (i sigma Omega) = 1 + s1 * s2 + s2 * s3 + s3 * s1 + i s1 * (s2 X s3)
+     *                         ------------------------------------------------
+     *                            2 (1 + s1 * s2) (1 + s2 * s3) (1 + s3 * s1)
+
+     * The denominator is a normalisation factor which we call rho, and i
+     * stands for an imaginary number in the numerator. The factor sigma is an
+     * orientation given by sign(s1 * s2 X s3), however, we do not use it since
+     * we take counter clock wise directions for the (s1, s2, s3) triangle of
+     * spins, as pointed out by Yin et al. [PRB 93, 174403 (2016)].
+     *
+     * Therefore we use a complex logarithm:
+
+     *      clog( r * exp(i theta) ) = r + i theta
+
+     * to calculate the angle Omega, since the clog is well defined in the
+     * [-PI, PI] range, giving the correct sign for the topological number (we
+     * could also use the arcsin when decomposing the exp).
+     *
+     * Notice we normalise the angle by a 4 PI factor
+     *
+     */
+
     double rho;
     double complex exp;
     double crossp[3];
@@ -180,8 +214,8 @@ double compute_BergLuscher_angle(double *s1, double *s2, double *s3){
                  * (1 + dot(&s3[0], &s1[0]))
                );
 
-    exp = (1 + dot(&s1[0], &s2[0]) 
-             + dot(&s2[0], &s3[0]) 
+    exp = (1 + dot(&s1[0], &s2[0])
+             + dot(&s2[0], &s3[0])
              + dot(&s3[0], &s1[0])
              + I * dot(&s1[0], &crossp[0])
            ) / rho;
@@ -193,16 +227,76 @@ double compute_BergLuscher_angle(double *s1, double *s2, double *s3){
 double skyrmion_number_BergLuscher(double *spin, double *charge,
                        int nx, int ny, int nz, int *ngbs) {
 
-    int n = nx * ny * nz;
-    int i, spin_index;
-    double total_sum = 0;
+    /* Compute the topological charge (or skyrmion number) by adding triangles
+     * of neighbouring spins for every lattice site, which cover triangle areas
+     * in a unit sphere (i.e. we map the lattice area into a unit sphere
+     * surface, using a triangulation). The exponential that defines every
+     * spherical angle was firstly mentioned by Berg and Luscher [Nucl Phys B
+     * 190, 412 (1981)] for a discrete square lattice but we generalise it here
+     * for hexagonal crystals.
+     *
+     * NEIGHBOURS DEFINITION:
+     *
+     * *ngbs is the array with the neighbours information for every lattice
+     * site. For cuboid meshes, the array is like:
+     *
+     *  NN:      j =0  j=1 ...                 j=0  j=1  ...
+     *         [ 0-x, 0+x, 0-y, 0+y, 0-z, 0+z, 1-x, 1+x, 1-y, ...  ]
+     *  spin:   i=6 * 0                        i=6 * 1
+     * ...
+     *
+     * where  0-y  is the index of the neighbour of the 0th spin, in the -y
+     * direction, for example, so the neighbours of the i-th spin start at the
+     * (6 * i) position of the array. This is similar for hexagonal meshes.
+     *
+     * For a cuboid mesh,  for the i-th spin, we generate the nearest ngbs
+     * triangles using the triangles: [i, j=1, j=3] , [i, j=0, j=2]
+     *                                     +x   +y         -x   -y
+     * i.e. we cover the top right and bottom left areas ( we could also use
+     * the top left and bottom right)
+     *
+     * For a hexagonal mesh,  for the i-th spin, we generate the nearest ngbs
+     * triangles using the triangles: [i, j=0, j=2] , [i, j=0, j=2]
+     *                                     E    NE         W    SW
+     *                                   (East) ...
+     * whose area covers a unit cell in a hexagonal crystal arrangement.
+     *
+     *
+     * Since the neighbours agree in indexes we can use the same function
+     * for both meshes.
+     *
+     * ------------------------------------------------------------------------
+     *
+     * Having the triangles defined, we compute the spherical triangle area
+     * spanned by the three spins using the compute_BergLuscher_angle function.
+     *
+     * The total topological charge Q is computed summing all triangles:
+     *                 __
+     *         Q  =   \     1   [ Omega(S_i, S_0, S_2) + Omega(S_i, S_1, S_3) ]
+     *                /__  ---
+     *                    4 PI
+     *                 i
+     *
+     * ehich are normalised by 4 PI, so we get an integer number for the number
+     * of times the unit sphere is covered by the spin directions in every
+     * triangle, e.g. if we have two skyrmions we get approximately Q = 2.
+     *
+     */
 
+    int n = nx * ny * nz; int i, spin_index; double total_sum = 0;
+
+    // Sweep through every lattice site
     for(i = 0; i < n; i++){
 
+        // x-y-z components for the i-th spin start at:
         spin_index = 3 * i;
 
+        // Reset the charge array
         charge[i] = 0;
 
+        // Compute the spherical triangle area for the triangle formed
+        // by the i-th spin and neighbours 0 and 2, i.e.
+        // [i j=0 j=2]. First check that the NNs exist:
         if(ngbs[6 * i] > 0 && ngbs[6 * i + 2] > 0){
             charge[i] += compute_BergLuscher_angle(&spin[spin_index],
                                                    &spin[3 * ngbs[6 * i]],
@@ -210,6 +304,7 @@ double skyrmion_number_BergLuscher(double *spin, double *charge,
                                                    );
         }
 
+        // Triangle: [i j=1 j=3]
         if(ngbs[6 * i + 1] > 0 && ngbs[6 * i + 3] > 0){
             charge[i] += compute_BergLuscher_angle(&spin[spin_index],
                                                    &spin[3 * ngbs[6 * i + 1]],

--- a/fidimag/atomistic/lib/util.c
+++ b/fidimag/atomistic/lib/util.c
@@ -194,22 +194,29 @@ double skyrmion_number_BergLuscher(double *spin, double *charge,
                        int nx, int ny, int nz, int *ngbs) {
 
     int n = nx * ny * nz;
-    int i, spin_index, nn_index;
+    int i, spin_index;
     double total_sum = 0;
 
     for(i = 0; i < n; i++){
 
         spin_index = 3 * i;
-        nn_index = 6 * ngbs[i];
 
-        charge[i] = compute_BergLuscher_angle(&spin[spin_index],
-                                              &spin[nn_index + 0],
-                                              &spin[nn_index + 2]
-                                              );
-        charge[i] += compute_BergLuscher_angle(&spin[spin_index],
-                                               &spin[nn_index + 1],
-                                               &spin[nn_index + 3]
-                                               );
+        charge[i] = 0;
+
+        if(ngbs[6 * i] > 0 && ngbs[6 * i + 2] > 0){
+            charge[i] += compute_BergLuscher_angle(&spin[spin_index],
+                                                   &spin[3 * ngbs[6 * i]],
+                                                   &spin[3 * ngbs[6 * i + 2]]
+                                                   );
+        }
+
+        if(ngbs[6 * i + 1] > 0 && ngbs[6 * i + 3] > 0){
+            charge[i] += compute_BergLuscher_angle(&spin[spin_index],
+                                                   &spin[3 * ngbs[6 * i + 1]],
+                                                   &spin[3 * ngbs[6 * i + 3]]
+                                                   );
+        }
+
         total_sum += charge[i];
     }
 

--- a/fidimag/atomistic/llg.py
+++ b/fidimag/atomistic/llg.py
@@ -300,6 +300,9 @@ class LLG(object):
         Calling this function will fill the _skx_number array with the skyrmion
         number density per lattice site.
 
+        It is important to mention that this calculation only works for a
+        2D layer in the XY plane.
+
         See the corresponding C code at fidimag/atomistic/lib/util.c for a
         detailed documentation about the methods.
 

--- a/fidimag/atomistic/llg.py
+++ b/fidimag/atomistic/llg.py
@@ -52,10 +52,10 @@ class LLG(object):
             'get': lambda sim: sim.compute_spin_error(),
             'header': 'm_error'}
 
-        self.saver.entities['skx_num'] = {
-            'unit': '<>',
-            'get': lambda sim: sim.skyrmion_number(),
-            'header': 'skx_num'}
+        # self.saver.entities['skx_num'] = {
+        #     'unit': '<>',
+        #     'get': lambda sim: sim.skyrmion_number(),
+        #     'header': 'skx_num'}
 
         self.saver.update_entity_order()
 

--- a/fidimag/atomistic/llg.py
+++ b/fidimag/atomistic/llg.py
@@ -297,6 +297,14 @@ class LLG(object):
             self.spin, self._skx_number, nx, ny, nz, self.mesh.neighbours)
         return number
 
+    def skyrmion_number_BergLuscher(self):
+        nx = self.mesh.nx
+        ny = self.mesh.ny
+        nz = self.mesh.nz
+        number = clib.compute_skyrmion_number_BergLuscher(
+            self.spin, self._skx_number, nx, ny, nz, self.mesh.neighbours)
+        return number
+
     def spin_at(self, i, j, k):
         """
         Returns the spin components of the spin at

--- a/fidimag/atomistic/llg.py
+++ b/fidimag/atomistic/llg.py
@@ -289,20 +289,41 @@ class LLG(object):
 
         return energy
 
-    def skyrmion_number(self):
-        nx = self.mesh.nx
-        ny = self.mesh.ny
-        nz = self.mesh.nz
-        number = clib.compute_skyrmion_number(
-            self.spin, self._skx_number, nx, ny, nz, self.mesh.neighbours)
-        return number
+    def skyrmion_number(self, method='FiniteSpinChirality'):
+        """
+        Calculate the skyrmion number using different methods:
 
-    def skyrmion_number_BergLuscher(self):
+        method      :: 'FiniteSpinChirality', 'BergLuscher'
+
+        which are specifically defined for discrete spin lattices.
+
+        Calling this function will fill the _skx_number array with the skyrmion
+        number density per lattice site.
+
+        See the corresponding C code at fidimag/atomistic/lib/util.c for a
+        detailed documentation about the methods.
+
+        """
         nx = self.mesh.nx
         ny = self.mesh.ny
         nz = self.mesh.nz
-        number = clib.compute_skyrmion_number_BergLuscher(
-            self.spin, self._skx_number, nx, ny, nz, self.mesh.neighbours)
+
+        if method == 'FiniteSpinChirality':
+            if self.mesh.mesh_type == 'cuboid':
+                number = clib.compute_skyrmion_number(
+                    self.spin, self._skx_number, nx, ny, nz,
+                    self.mesh.neighbours)
+            else:
+                raise ValueError('FiniteSpinChirality method only'
+                                 ' defined for cuboid meshes')
+
+        elif method == 'BergLuscher':
+            number = clib.compute_skyrmion_number_BergLuscher(
+                self.spin, self._skx_number, nx, ny, nz,
+                self.mesh.neighbours)
+        else:
+            raise ValueError('Specify a valid method')
+
         return number
 
     def spin_at(self, i, j, k):

--- a/tests/test_skyrmion_number.py
+++ b/tests/test_skyrmion_number.py
@@ -1,15 +1,21 @@
 from __future__ import print_function
 from fidimag.atomistic import Sim
 from fidimag.common import CuboidMesh
+from fidimag.atomistic.hexagonal_mesh import HexagonalMesh
 from fidimag.atomistic import DMI
 from fidimag.atomistic import UniformExchange
 from fidimag.atomistic import Zeeman
+from fidimag.atomistic import Anisotropy
 
 from fidimag.micro import DMI as microDMI
 from fidimag.micro import UniaxialAnisotropy as microUniaxialAnisotropy
 from fidimag.micro import UniformExchange as microUniformExchange
 from fidimag.micro import Zeeman as microZeeman
 from fidimag.micro import Sim as microSim
+
+import fidimag.common.constant as const
+
+import numpy as np
 
 
 def init_m(pos, x0, y0, r):
@@ -25,6 +31,20 @@ def init_m(pos, x0, y0, r):
         return m1
     else:
         return m2
+
+
+def init_m_multiple_sks(pos, r, sk_pos):
+    # Generate singularities with radius r at the positions in the
+    # sk_pos list, in order to generate multiple skyrmions after
+    # relaxation. Example: sk_pos=[(1, 1), (2, 2)]
+    #                               x  y
+    x, y = pos[0], pos[1]
+
+    for coord in sk_pos:
+        if (x - coord[0]) ** 2 + (y - coord[1]) ** 2 < r ** 2:
+            return (0, 0, 1)
+
+    return (0, 0, -1)
 
 
 def test_skx_num_atomistic():
@@ -44,6 +64,10 @@ def test_skx_num_atomistic():
 
     The area of the two triangles cover a unit cell, thus the sum
     cover the whole area of the atomic lattice
+
+    We also test the Berg and Luscher definition for a topological
+    charge (see the hexagonal mesh test for details) in a
+    square lattice.
 
     This test generate a skyrmion pointing down with unrealistic
     paremeters.
@@ -79,7 +103,81 @@ def test_skx_num_atomistic():
 
     skn = sim.skyrmion_number()
     print('skx_number', skn)
+
+    skn_BL = sim.skyrmion_number(method='BergLuscher')
+    print('skx_number_BergLuscher', skn_BL)
+
+    # Test the finite chirality method
     assert skn > -1 and skn < -0.99
+
+    # Test the Berg-Luscher method
+    assert np.abs(skn_BL - (-1)) < 1e-4 and np.sign(skn_BL) < 0
+
+
+def test_skx_num_atomistic_hexagonal():
+    """
+
+    Test the topological charge or skyrmion number for a discrete spins
+    simulation in a two dimensional hexagonal lattice, using Berg and Luscher
+    definition in [Nucl Phys B 190, 412 (1981)] and simplified in [PRB 93,
+    174403 (2016)], which maps a triangulated lattice (using triangles of
+    neighbouring spins) area into a unit sphere.
+
+    The areas of two triangles per lattice site cover a unit cell, thus the sum
+    cover the whole area of the atomic lattice
+
+    This test generates a skyrmion pointing down and two skyrmions pointing up
+    in a PdFe sample using magnetic parameters from: PRL 114, 177203 (2015)
+
+    """
+
+    mesh = HexagonalMesh(0.2715, 41, 41, periodicity=(True, True))
+
+    sim = Sim(mesh, name='skx_number_hexagonal')
+    sim.set_tols(rtol=1e-6, atol=1e-6)
+    sim.alpha = 1.0
+    sim.gamma = 1.0
+    sim.mu_s = 3 * const.mu_B
+
+    sim.set_m(lambda pos: init_m(pos, 16.1, 10, 2))
+
+    sim.do_precession = False
+
+    J = 5.881 * const.meV
+    exch = UniformExchange(J)
+    sim.add(exch)
+
+    D = 1.557 * const.meV
+    dmi = DMI(D, dmi_type='interfacial')
+    sim.add(dmi)
+
+    sim.add(Anisotropy(0.406 * const.meV, axis=[0, 0, 1]))
+
+    zeeman = Zeeman([0, 0, 2.5])
+    sim.add(zeeman)
+
+    sim.relax(dt=1e-13, stopping_dmdt=1e-2, max_steps=2000,
+              save_m_steps=None, save_vtk_steps=100)
+
+    skn_single = sim.skyrmion_number(method='BergLuscher')
+    print('skx_number_hexagonal', skn_single)
+
+    # Now we generate two skyrmions pointing up
+    sim.reset_integrator()
+    sim.set_m(lambda pos: init_m_multiple_sks(pos, 1,
+                                              sk_pos=[(9, 6), (18, 12)]
+                                              )
+              )
+    sim.get_interaction('Zeeman').update_field([0, 0, -2.5])
+    sim.relax(dt=1e-13, stopping_dmdt=1e-2, max_steps=2000,
+              save_m_steps=None, save_vtk_steps=None)
+
+    skn_two = sim.skyrmion_number(method='BergLuscher')
+    print('skx_number_hexagonal', skn_two)
+
+    # Check that we get a right sk number
+    assert np.abs(skn_single - (-1)) < 1e-4 and np.sign(skn_single) < 0
+    assert np.abs(skn_two - (2)) < 1e-4 and np.sign(skn_two) > 0
 
 
 def test_skx_num_micromagnetic():
@@ -145,4 +243,5 @@ def test_skx_num_micromagnetic():
 if __name__ == '__main__':
 
     test_skx_num_atomistic()
+    test_skx_num_atomistic_hexagonal()
     test_skx_num_micromagnetic()


### PR DESCRIPTION
I added a new method based on Berg and Luscher paper http://www.sciencedirect.com/science/article/pii/055032138190568X which allows us to compute the topological charge / skyrmion number in a hexagonal lattice and also in a Cuboid mesh. I documented the corresponding function in the LLG class and left as default the `FiniteSpinChirality` method, which only works for cuboid meshes. So I removed the skyrmion number from the log file that fidimag generates, since the default sk number is meaningless for a hexagonal mesh.