### PR TITLE
Sort out libblas dependency problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,13 @@ python:
         - "2.7"
 sudo: false
 # command to install dependencies
+
+addons:
+  apt:
+    sources:
+      - libblas-dev
+      - liblapack-dev
+
 before_install:
   # We do this conditionally because it saves us some downloading if the
   # version is the same.

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,7 @@ python:
         - "3.5"
         - "3.4"
         - "2.7"
-sudo: false
-# command to install dependencies
 
-addons:
-  apt:
-    sources:
-      - libblas-dev
-      - liblapack-dev
 
 before_install:
   # We do this conditionally because it saves us some downloading if the
@@ -23,7 +16,7 @@ before_install:
     fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH=/home/travis/miniconda/bin:$PATH
-
+  - sudo apt-get install liblapack-dev libblas-dev
 install:
   - conda create -q -y -n fidimag-test python=$TRAVIS_PYTHON_VERSION cython matplotlib pytest scipy pytest-cov gcc cmake psutil
   - source activate fidimag-test


### PR DESCRIPTION
This just fixes the libblas travis problems once we'd specified it as an explicit apt-get dependency in setup.py