### PR TITLE
Micro dmi

### DIFF
--- a/fidimag/micro/dmi.py
+++ b/fidimag/micro/dmi.py
@@ -85,7 +85,7 @@ class DMI(Energy):
         self.Ds = np.zeros(self.NN * self.n, dtype=np.float)
 
         if isinstance(self.D, np.ndarray) and len(self.D) == self.NN * self.n:
-            self.Ds = self.D
+            self.Ds = self.D.astype('float')
         # If we do not pass a (NN * n) array, we just create a scalar field as
         # usual and then repeat the entries NN times so every neighbour will
         # have the same DMI per lattice site (can vary spatially)

--- a/fidimag/micro/dmi.py
+++ b/fidimag/micro/dmi.py
@@ -9,12 +9,40 @@ import gc
 class DMI(Energy):
 
     """
-        compute the DMI field in micromagnetics
+
+    Compute the Dzyaloshinskii-Moriya interaction in the micromagnetic
+    framework
+
+    ARGUMENTS: ----------------------------------------------------------------
+
+    D       ::
+
+               DMI vector norm which can be specified as an int, float, (X * n)
+               array (X=6 for bulk DMI and X=4 for interfacial DMI), (n) array
+               or spatially dependent scalar field function.
+
+               int, float: D will have the same magnitude for every NN of the
+               spins at every mesh node, given by this magnitude
+
+               (n) array: D will have the same magnitude for every NN on every
+               mesh node but will vary according to the values of the array,
+               i.e. the value of D for the 6 NNs at the i-th mesh site will be
+               given by the i-th value of the array
+
+               (X * n) array: Manually specify the DMI vector norm for every NN
+               at every mesh node. The bulk DMI considers the 6 NNs from every
+               node an interfacial DMI is D so it only considers 4 NNs from the
+               xy plane.
+
+    OPTIONAL ARGUMENTS: -------------------------------------------------------
+
+    dmi_type        :: 'bulk' or 'interfacial'
+    name            :: Interaction name
+
     """
 
     def __init__(self, D, name='DMI', dmi_type='bulk'):
         """
-        type could be 'interfacial' or 'bulk'
         """
         self.D = D
         self.name = name
@@ -23,8 +51,22 @@ class DMI(Energy):
 
     def setup(self, mesh, spin, Ms):
         super(DMI, self).setup(mesh, spin, Ms)
-        self.Ds = np.zeros(self.n, dtype=np.float)
-        self.Ds[:] = helper.init_scalar(self.D, self.mesh)
+
+        # We will allow to completely specify the DMI vectors according to the
+        # NNs of every lattice site, thus we need a matrix of 6 * n entries
+        self.Ds = np.zeros(6 * self.n, dtype=np.float)
+
+        if isinstance(self.D, np.ndarray) and len(self.D) == 6 * self.n:
+            self.Ds = self.D
+        # If we do not pass a (6 * n) array, we just create a scalar field as
+        # usual and then repeat the entries 6 times so every neighbour will
+        # have the same DMI per lattice site (can vary spatially)
+        else:
+            D_array = helper.init_scalar(self.D, self.mesh)
+            self.Ds = np.repeat(D_array, 6)
+
+        # This is from the original code:
+        # self.Ds[:] = helper.init_scalar(self.D, self.mesh)
 
     def compute_field(self, t=0, spin=None):
         if spin is not None:

--- a/fidimag/micro/lib/dmi.c
+++ b/fidimag/micro/lib/dmi.c
@@ -12,11 +12,12 @@
 * Ms_inv     :: Array with the (1 / Ms) values for every mesh node.
 *               The values are zero for points with Ms = 0 (no material)
 *
-* D          :: Array with the DMI constant values
+* D          :: Array with the DMI constant values (see the description on each
+*               function for a detailed explanation)
 *
 * dx, dy, dz :: Mesh spacings in the corresponding directions
 *
-* n       :: Number of mesh nodes
+* n          :: Number of mesh nodes
 *
 * ngbs       :: The array of neighbouring spins, which has (6 * n)
 *               entries. Specifically, it contains the indexes of
@@ -270,6 +271,17 @@ void dmi_field_interfacial(double *m, double *field, double *energy, double *Ms_
      * If we start with this picture in the atomic model, we can get the
      * continuum expression when doing the limit  a_x a_y a_z  --> 0
      *
+     *  The DMI vector norms are given by the *D array. If our simulation has
+     *  n mesh nodes, then the D array is (4 * n) long, i.e. the DMI vector norm
+     *  per every neighbour per every mesh node. The order is the same than the NNs
+     *  array, i.e. 
+     *
+     *      D = [D(x)_0, D(-x)_0, D(y)_0, D(-y)_0, D(x)_1, ...]
+     *
+     *  where D(j)_i means the DMI vector norm of the NN in the j-direction at
+     *  the i-th mesh node. Remember that the DMI vector points in a single
+     *  direction towards the NN site, e.g. the DMI vector of the NN in the
+     *  +y direction for the 0th spin, is DMI_vector = D(y)_0 * (0, 1, 0)
      */
 
     /* We set the DMi vectors here. For the j-th NN, the DMI
@@ -292,6 +304,7 @@ void dmi_field_interfacial(double *m, double *field, double *energy, double *Ms_
 	    double fx = 0, fy = 0, fz = 0;
 	    int idnm = 0;     // Index for the magnetisation matrix
 	    int idn = 6 * i; // index for the neighbours
+	    int idn_DMI = 4 * i; // index for the neighbours for the DMI array
 
         /* Set a zero field for sites without magnetic material */
 	    if (Ms_inv[i] == 0.0){
@@ -309,15 +322,15 @@ void dmi_field_interfacial(double *m, double *field, double *energy, double *Ms_
 	        if (ngbs[idn + j] >= 0) {
 
                 /* DMI coefficient according to the neighbour position */
-                DMIc = D[i] / dxs[j];
+                DMIc = D[idn_DMI + j] / dxs[j];
 
                 /* Magnetisation array index of the neighbouring spin
                  * since ngbs gives the neighbour's index */
 	            idnm = 3 * ngbs[idn + j];
 
                 /* Check that the magnetisation of the neighbouring spin
-                 * is larger than zero */
-                if (Ms_inv[ngbs[idn + j]] > 0){
+                 * is larger than zero, as well as the DMI coefficient */
+                if (Ms_inv[ngbs[idn + j]] > 0 && abs(DMIc) > 0) {
 
                     fx += DMIc * cross_x(dmivector[3 * j],
                                          dmivector[3 * j + 1],

--- a/fidimag/micro/lib/micro_clib.pyx
+++ b/fidimag/micro/lib/micro_clib.pyx
@@ -28,36 +28,36 @@ cdef extern from "micro_clib.h":
 
 
 def compute_exchange_field_micro(np.ndarray[double, ndim=1, mode="c"] m,
-                            np.ndarray[double, ndim=1, mode="c"] field,
-                            np.ndarray[double, ndim=1, mode="c"] energy,
-                            np.ndarray[double, ndim=1, mode="c"] Ms_inv,
-                            A, dx, dy, dz, n,
-            		    np.ndarray[int, ndim=2, mode="c"] ngbs):
+                                 np.ndarray[double, ndim=1, mode="c"] field,
+                                 np.ndarray[double, ndim=1, mode="c"] energy,
+                                 np.ndarray[double, ndim=1, mode="c"] Ms_inv,
+                                 A, dx, dy, dz, n,
+            		             np.ndarray[int, ndim=2, mode="c"] ngbs):
 
     compute_exch_field_micro(&m[0], &field[0], &energy[0], &Ms_inv[0], A,
                              dx, dy, dz, n, &ngbs[0, 0])
     
 
 def compute_dmi_field_bulk(np.ndarray[double, ndim=1, mode="c"] m,
-                            np.ndarray[double, ndim=1, mode="c"] field,
-                            np.ndarray[double, ndim=1, mode="c"] energy,
-                            np.ndarray[double, ndim=1, mode="c"] Ms_inv,
-                            np.ndarray[double, ndim=1, mode="c"] D,
-                            dx, dy, dz,
-                            n, np.ndarray[int, ndim=2, mode="c"] ngbs
-                            ):
+                           np.ndarray[double, ndim=1, mode="c"] field,
+                           np.ndarray[double, ndim=1, mode="c"] energy,
+                           np.ndarray[double, ndim=1, mode="c"] Ms_inv,
+                           np.ndarray[double, ndim=1, mode="c"] D,
+                           dx, dy, dz,
+                           n, np.ndarray[int, ndim=2, mode="c"] ngbs
+                           ):
 
     dmi_field_bulk(&m[0], &field[0], &energy[0], &Ms_inv[0], &D[0],
                    dx, dy, dz, n, &ngbs[0, 0])
     
 def compute_dmi_field_interfacial(np.ndarray[double, ndim=1, mode="c"] m,
-                            np.ndarray[double, ndim=1, mode="c"] field,
-                            np.ndarray[double, ndim=1, mode="c"] energy,
-                            np.ndarray[double, ndim=1, mode="c"] Ms_inv,
-                            np.ndarray[double, ndim=1, mode="c"] D,
-                            dx, dy, dz, 
-                            n, np.ndarray[int, ndim=2, mode="c"] ngbs
-                            ):
+                                  np.ndarray[double, ndim=1, mode="c"] field,
+                                  np.ndarray[double, ndim=1, mode="c"] energy,
+                                  np.ndarray[double, ndim=1, mode="c"] Ms_inv,
+                                  np.ndarray[double, ndim=1, mode="c"] D,
+                                  dx, dy, dz, 
+                                  n, np.ndarray[int, ndim=2, mode="c"] ngbs
+                                  ):
 
     dmi_field_interfacial(&m[0], &field[0], &energy[0], &Ms_inv[0], &D[0],
                           dx, dy, dz, n, &ngbs[0, 0])

--- a/tests/test_dmi.py
+++ b/tests/test_dmi.py
@@ -1,17 +1,20 @@
-from fidimag.atomistic import DMI
 from fidimag.common import CuboidMesh
-from fidimag.atomistic import Sim
+from fidimag.atomistic import DMI as atomDMI
+from fidimag.atomistic import Sim as atomSim
+from fidimag.micro import DMI as microDMI
+from fidimag.micro import Sim as microSim
 import numpy as np
+import fidimag.common.constant as C
 
 
-def test_dmi_1d():
+def test_atom_dmi_1d():
 
     mesh = CuboidMesh(nx=2, ny=1, nz=1)
 
-    sim = Sim(mesh)
+    sim = atomSim(mesh)
     sim.set_m((1, 0, 0))
 
-    dmi = DMI(D=1)
+    dmi = atomDMI(D=1)
     sim.add(dmi)
 
     field = dmi.compute_field()
@@ -31,14 +34,14 @@ def init_m(pos):
         return (0, 0, 1)
 
 
-def test_dmi_1d_field():
+def test_atom_dmi_1d_field():
 
     mesh = CuboidMesh(nx=2, ny=1, nz=1)
 
-    sim = Sim(mesh)
+    sim = atomSim(mesh)
     sim.set_m(init_m)
 
-    dmi = DMI(D=1.23)
+    dmi = atomDMI(D=1.23)
     sim.add(dmi)
 
     field = dmi.compute_field()
@@ -51,6 +54,109 @@ def test_dmi_1d_field():
 
     assert energy == 1.23
 
+
+def test_micro_dmi_array_bulk():
+    """
+    Test the DMI in a micromagnetic simulation when manually specifying
+    the DMI array. We use bulk DMI
+
+    We specify DMI only along the +- z directions by setting the
+    magnitude of the DMI vector along the other directions as 0
+
+    The system consists of 4 spins in the xz plane aligned as:
+          2        3
+            X    X                z ^  . y
+                                    | /
+           -->  <--                 |/___> x
+          0        1
+
+    i.e. in the +x, -x, +y, +y directions. Thus the DMI field in this case, for
+    the 0th node, is only computed using the 2nd node. Similarly for the
+    others, because the DMI is only defined for NNs along the z directions.
+
+    """
+    D = 1
+    # The DMI norms for the NNs: -x +x -y +y -z +z
+    DMInorms = np.array([0, 0, 0, 0, D, D])
+    # This norm is the same for every lattice site
+    DMInorms = np.repeat(DMInorms[np.newaxis, :], 4, axis=0).flatten()
+
+    mesh = CuboidMesh(nx=2, ny=1, nz=2, dx=1, dy=1, dz=1)
+    sim = microSim(mesh)
+    sim.Ms = 1
+    sim.set_m(np.array([1, 0, 0,
+                        -1, 0, 0,
+                        0, 1, 0,
+                        0, 1, 0]))
+
+    sim.add(microDMI(DMInorms, dmi_type='bulk'))
+    sim.compute_effective_field(0)
+
+    # The field is computed as: - (1 / mu_0 Ms) D ( r_ij X M )
+    # Thus the field at the 0th site should be: -D ( z X (0, 1, 0) )
+    # which is (1, 0, 0), since Ms=1 and D is defined only for the
+    # neighbours as +- z
+    D_field = sim.field.reshape(-1, 3)
+    hx, hy, hz = C.mu_0 * D_field[0]
+    assert np.abs(hx - 1) < 1e-10
+    assert np.abs(hy) < 1e-10
+    assert np.abs(hz) < 1e-10
+
+
+def test_micro_dmi_array_interfacial():
+    """
+    Test the DMI in a micromagnetic simulation when manually specifying
+    the DMI array. Here we use interfacial DMI (only defined for NNs
+    in the xy plane)
+
+    We specify DMI only along the +x direction by setting the
+    magnitude of the DMI vector along the other directions as 0
+
+    The system consists of 3 spins in the xz plane aligned as:
+
+                                     z ^  . y
+           -->   X   |                 | /
+                     v                 |/___> x
+          0      1   2
+
+    i.e. in the +x, +y, -z directions. Thus the DMI field in this case, for
+    the 1st node, is only computed using the 2nd node.
+
+    """
+    D = 1
+    # The DMI norms for the NNs: -x +x -y +y -z +z
+    DMInorms = np.array([0, D, 0, D])
+    # This norm is the same for every lattice site
+    DMInorms = np.repeat(DMInorms[np.newaxis, :], 3, axis=0).flatten()
+
+    mesh = CuboidMesh(nx=3, ny=1, nz=1, dx=1, dy=1, dz=1)
+    sim = microSim(mesh)
+    sim.Ms = 1
+    sim.set_m(np.array([1, 0, 0,
+                        0, 1, 0,
+                        0, 0, -1]))
+
+    sim.add(microDMI(DMInorms, dmi_type='interfacial'))
+    sim.compute_effective_field(0)
+
+    # The field is computed as: - (1 / mu_0 Ms) D ( (r_ij X z) X M )
+    # Thus the field at the middle site should be: -D ( (-y) X (0, 0, -1) )
+    # which is (1, 0, 0), since Ms=1 and D is defined only for the
+    # neighbours as +- z
+    D_field = sim.field.reshape(-1, 3)
+    hx, hy, hz = C.mu_0 * D_field[1]
+    assert np.abs(hx - 1) < 1e-10
+    assert np.abs(hy) < 1e-10
+    assert np.abs(hz) < 1e-10
+
+    # At the first site the field is zero
+    hx, hy, hz = C.mu_0 * D_field[0]
+    assert np.abs(hx) < 1e-10
+    assert np.abs(hy) < 1e-10
+    assert np.abs(hz) < 1e-10
+
 if __name__ == '__main__':
-    test_dmi_1d()
-    test_dmi_1d_field()
+    test_atom_dmi_1d()
+    test_atom_dmi_1d_field()
+    test_micro_dmi_array_bulk()
+    test_micro_dmi_array_interfacial()


### PR DESCRIPTION
These changes are a generalisation for the specification of the DMI vector norms in the micromagnetic code. I basically added the option to specify the value of `D` per every nearest neighbour at every lattice site, by specifying (in the case of bulk DMI) an array `6 * n` long where `n` is the number of mesh sites and `6` comes from the number of NNs. 
This allows us, for example, to specify a bulk DMI without interlayer interaction (`D` = 0 for the `+-z` neighbours. This case is in one of the tests).