### PR TITLE
Cvode bug

### DIFF
--- a/fidimag/common/sim_base.py
+++ b/fidimag/common/sim_base.py
@@ -87,7 +87,6 @@ class SimBase(object):
 
         """
 
-        print(self.spin)
         self.spin[:] = helper.init_vector(m0, self.mesh, normalise)
 
         # TODO: carefully checking and requires to call set_mu first

--- a/fidimag/common/sim_base.py
+++ b/fidimag/common/sim_base.py
@@ -87,6 +87,7 @@ class SimBase(object):
 
         """
 
+        print(self.spin)
         self.spin[:] = helper.init_vector(m0, self.mesh, normalise)
 
         # TODO: carefully checking and requires to call set_mu first

--- a/fidimag/common/sundials/cvode.pxd
+++ b/fidimag/common/sundials/cvode.pxd
@@ -9,7 +9,7 @@ cdef extern from "sundials/sundials_nvector.h":
         
     ctypedef _generic_N_Vector *N_Vector
     N_Vector N_VNew_Serial(long int vec_length)
-    N_Vector N_VNew_OpenMP(long int vec_length)
+    N_Vector N_VNew_OpenMP(long int vec_length, int num_threads)
     void N_VDestroy_Serial(N_Vector v)
     void N_VDestroy_OpenMP(N_Vector v)
     void N_VPrint_Serial(N_Vector v)

--- a/fidimag/common/sundials/cvode.pyx
+++ b/fidimag/common/sundials/cvode.pyx
@@ -179,6 +179,7 @@ cdef class CvodeSolver(object):
         self.check_flag(flag, "CVodeSetUserData")
 
         self.cvode_already_initialised = 0
+        self.u_y = N_VNew_Serial(self.y.size)
         self.set_initial_value(spins, self.t)
         self.set_options(rtol, atol)
 
@@ -191,7 +192,8 @@ cdef class CvodeSolver(object):
         self.y[:] = spin[:]
 
         cdef np.ndarray[double, ndim = 1, mode = "c"] y = self.y
-        self.u_y = N_VMake_Serial(y.size, & y[0])
+        copy_arr2nv(self.y, self.u_y)
+        N_VPrint_Serial(self.u_y)
 
         if self.cvode_already_initialised:
             flag = CVodeReInit(self.cvode_mem, t, self.u_y)
@@ -363,6 +365,7 @@ cdef class CvodeSolver_OpenMP(object):
         self.check_flag(flag, "CVodeSetUserData")
 
         self.cvode_already_initialised = 0
+        self.u_y = N_VNew_OpenMP(self.y.size, self.num_threads)
         self.set_initial_value(spins, self.t)
         self.set_options(rtol, atol)
 
@@ -375,7 +378,7 @@ cdef class CvodeSolver_OpenMP(object):
         self.y[:] = spin[:]
 
         cdef np.ndarray[double, ndim = 1, mode = "c"] y = self.y
-        self.u_y = N_VMake_OpenMP(y.size, &y[0], self.num_threads)
+        copy_arr2nv_openmp(self.y, self.u_y)
 
         if self.cvode_already_initialised:
             flag = CVodeReInit(self.cvode_mem, t, self.u_y)

--- a/fidimag/common/sundials/cvode.pyx
+++ b/fidimag/common/sundials/cvode.pyx
@@ -4,6 +4,7 @@ cimport numpy as np  # import special compile-time information about numpy
 cimport openmp
 np.import_array()  # don't remove or you'll segfault
 from libc.string cimport memcpy
+import sys
 
 cdef extern from "../../atomistic/lib/clib.h":
     void normalise(double * m, int nxyz)
@@ -179,7 +180,9 @@ cdef class CvodeSolver(object):
         self.check_flag(flag, "CVodeSetUserData")
 
         self.cvode_already_initialised = 0
-        self.u_y = N_VNew_Serial(self.y.size)
+
+        self.u_y = N_VMake_Serial(self.y.size, <realtype *> self.y.data)
+
         self.set_initial_value(spins, self.t)
         self.set_options(rtol, atol)
 
@@ -193,7 +196,6 @@ cdef class CvodeSolver(object):
 
         cdef np.ndarray[double, ndim = 1, mode = "c"] y = self.y
         copy_arr2nv(self.y, self.u_y)
-        N_VPrint_Serial(self.u_y)
 
         if self.cvode_already_initialised:
             flag = CVodeReInit(self.cvode_mem, t, self.u_y)
@@ -365,7 +367,9 @@ cdef class CvodeSolver_OpenMP(object):
         self.check_flag(flag, "CVodeSetUserData")
 
         self.cvode_already_initialised = 0
-        self.u_y = N_VNew_OpenMP(self.y.size, self.num_threads)
+
+        self.u_y = N_VMake_OpenMP(self.y.size, <realtype *> self.y.data, self.num_threads)
+
         self.set_initial_value(spins, self.t)
         self.set_options(rtol, atol)
 

--- a/fidimag/common/vtk.py
+++ b/fidimag/common/vtk.py
@@ -21,7 +21,6 @@ class VTK(object):
             # for keyword argument dimensions: if the mesh is made up of
             # nx * ny * nz cells, it has (nx + 1) * (ny + 1) * (nz + 1)
             # vertices.
-            print(mesh.grid)
             structure = pyvtk.RectilinearGrid(* mesh.grid)
         else:
             raise NotImplementedError(


### PR DESCRIPTION
This branch fixes the memory leak in the `CVODE` Cython code, where a new `u_y` `NVector` from Sundials is created every time the `set_m` method from the `Sim` class is  called.
The workaround was to create a `u_y` at the init of the `CVODE` class and then just rewrite its contents when the integrator is reinitialised.

Hopefully, this branch will solve Issue #97 
Overall, the Cython code for Sundials is not very clear (specially for debugging) and we should use a more simple version in the future.