### PR TITLE
Refactor magnetisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,12 +10,14 @@
 
 # ignore automatically generated cython files
 fidimag/atomistic/lib/clib.c
+fidimag/common/lib/common_clib.c
 fidimag/common/dipolar/dipolar.c
 fidimag/common/neb/neb_clib.c
 fidimag/common/neb_method/*clib.c
 fidimag/common/sundials/cvode.c
 fidimag/micro/lib/baryakhtar/baryakhtar_clib.c
 fidimag/micro/lib/micro_clib.c
+fidimag/user/example/example.c
 
 # ignore .cache from pytest
 .cache

--- a/fidimag/atomistic/anisotropy.py
+++ b/fidimag/atomistic/anisotropy.py
@@ -65,13 +65,14 @@ class Anisotropy(Energy):
 
         clib.compute_anisotropy(m,
                                 self.field,
+                                self.mu_s_inv,
                                 self.energy,
                                 self._Ku,
                                 self._axis,
                                 self.n
                                 )
 
-        return self.field * self.mu_s_inv
+        return self.field
 
 
 class CubicAnisotropy(Energy):
@@ -84,7 +85,6 @@ class CubicAnisotropy(Energy):
         self.name = name
         self.jac = True
 
-
     def setup(self, mesh, spin, mu_s, mu_s_inv):
         super(CubicAnisotropy, self).setup(mesh, spin, mu_s, mu_s_inv)
         self._Kc = helper.init_scalar(self.Kc, self.mesh)
@@ -96,9 +96,10 @@ class CubicAnisotropy(Energy):
             m = self.spin
 
         clib.compute_anisotropy_cubic(m,
-                                self.field,
-                                self.energy,
-                                self._Kc,
-                                self.n)
+                                      self.field,
+                                      self.mu_s_inv,
+                                      self.energy,
+                                      self._Kc,
+                                      self.n)
 
-        return self.field * self.mu_s_inv
+        return self.field

--- a/fidimag/atomistic/anisotropy.py
+++ b/fidimag/atomistic/anisotropy.py
@@ -50,8 +50,8 @@ class Anisotropy(Energy):
         self.axis = axis
         self.jac = True
 
-    def setup(self, mesh, spin, mu_s):
-        super(Anisotropy, self).setup(mesh, spin, mu_s)
+    def setup(self, mesh, spin, mu_s, mu_s_inv):
+        super(Anisotropy, self).setup(mesh, spin, mu_s, mu_s_inv)
 
         self._Ku = helper.init_scalar(self.Ku, self.mesh)
         self._axis = helper.init_vector(self.axis, self.mesh, True)
@@ -85,8 +85,8 @@ class CubicAnisotropy(Energy):
         self.jac = True
 
 
-    def setup(self, mesh, spin, mu_s):
-        super(CubicAnisotropy, self).setup(mesh, spin, mu_s)
+    def setup(self, mesh, spin, mu_s, mu_s_inv):
+        super(CubicAnisotropy, self).setup(mesh, spin, mu_s, mu_s_inv)
         self._Kc = helper.init_scalar(self.Kc, self.mesh)
 
     def compute_field(self, t=0, spin=None):

--- a/fidimag/atomistic/atomistic_driver.py
+++ b/fidimag/atomistic/atomistic_driver.py
@@ -133,7 +133,11 @@ class AtomisticDriver(DriverBase):
         # When we create the simulation, mu_s is set to the default value. This
         # is overriden when calling the set_mu_s method from the Simulation
         # class or when setting mu_s directly (property)
+        # David Tue 19 Jun 2018: Not a very clear thing to do, we must set a
+        # WARNING
         self._mu_s[:] = mu_s
+        self._mu_s_inv[:] = 1. / mu_s
+
         self.mu_s_const = mu_s
         self.gamma = gamma
         self.do_precession = True

--- a/fidimag/atomistic/demag.py
+++ b/fidimag/atomistic/demag.py
@@ -1,8 +1,9 @@
 import fidimag.extensions.dipolar as clib
 import numpy as np
+from .energy import Energy
 
 
-class Demag(object):
+class Demag(Energy):
     """
 
     Energy class for the demagnetising field (a.k.a. dipolar interactions,
@@ -38,22 +39,8 @@ class Demag(object):
         self.jac = True
 
     def setup(self, mesh, spin, mu_s, mu_s_inv):
-        self.mesh = mesh
-        self.dx = mesh.dx
-        self.dy = mesh.dy
-        self.dz = mesh.dz
-        self.nx = mesh.nx
-        self.ny = mesh.ny
-        self.nz = mesh.nz
-        self.spin = spin
-        self.mu_s = mu_s
-        self.n = mesh.n
-        self.field = np.zeros(3 * self.n, dtype=np.float)
-        unit_length = mesh.unit_length
-        self.mu_s_scale = np.zeros(mesh.n, dtype=np.float)
-
-        # note that the 1e-7 comes from \frac{\mu_0}{4\pi}
-        self.scale = 1e-7 / unit_length**3
+        super(Demag, self).setup(mesh, spin, mu_s, mu_s_inv)
+        self.scale = 1e-7 / mesh.unit_length**3
 
         # could be wrong, needs carefully tests!!!
         # David Tue 19 Jun 2018: This variable is updated in the SIM class in

--- a/fidimag/atomistic/demag.py
+++ b/fidimag/atomistic/demag.py
@@ -37,7 +37,7 @@ class Demag(object):
         self.name = name
         self.jac = True
 
-    def setup(self, mesh, spin, mu_s):
+    def setup(self, mesh, spin, mu_s, mu_s_inv):
         self.mesh = mesh
         self.dx = mesh.dx
         self.dy = mesh.dy
@@ -46,6 +46,7 @@ class Demag(object):
         self.ny = mesh.ny
         self.nz = mesh.nz
         self.spin = spin
+        self.mu_s = mu_s
         self.n = mesh.n
         self.field = np.zeros(3 * self.n, dtype=np.float)
         unit_length = mesh.unit_length
@@ -55,6 +56,8 @@ class Demag(object):
         self.scale = 1e-7 / unit_length**3
 
         # could be wrong, needs carefully tests!!!
+        # David Tue 19 Jun 2018: This variable is updated in the SIM class in
+        # case mu_s changes
         self.mu_s_scale = mu_s * self.scale
 
         self.demag = clib.FFTDemag(self.dx, self.dy, self.dz,

--- a/fidimag/atomistic/demag_full.py
+++ b/fidimag/atomistic/demag_full.py
@@ -18,8 +18,8 @@ class DemagFull(Energy):
         self.name = name
         self.jac = True
 
-    def setup(self, mesh, spin, mu_s):
-        super(DemagFull, self).setup(mesh, spin, mu_s)
+    def setup(self, mesh, spin, mu_s, mu_s_inv):
+        super(DemagFull, self).setup(mesh, spin, mu_s, mu_s_inv)
 
         unit_length = mesh.unit_length
         self.mu_s_scale = np.zeros(mesh.n, dtype=np.float)

--- a/fidimag/atomistic/demag_hexagonal.py
+++ b/fidimag/atomistic/demag_hexagonal.py
@@ -51,7 +51,7 @@ class DemagHexagonal(object):
         self.name = name
         self.jac = True
 
-    def setup(self, mesh, spin, mu_s):
+    def setup(self, mesh, spin, mu_s, mu_s_inv):
 
         if mesh.mesh_type != 'hexagonal':
             raise Exception('This interaction is only defined'
@@ -89,6 +89,8 @@ class DemagHexagonal(object):
         self.scale = 1e-7 / unit_length ** 3
 
         # could be wrong, needs carefully tests!!!
+        # David Tue 19 Jun 2018: this variable is upated in the sim class
+        # in case mu_s changes
         self.mu_s_scale = mu_s * self.scale
 
         # This seems not to be necessary

--- a/fidimag/atomistic/dmi.py
+++ b/fidimag/atomistic/dmi.py
@@ -120,6 +120,7 @@ class DMI(Energy):
         if self.dmi_type == 'bulk':
             clib.compute_dmi_field(m,
                                    self.field,
+                                   self.mu_s_inv,
                                    self.energy,
                                    self._D,
                                    self.neighbours,
@@ -131,6 +132,7 @@ class DMI(Energy):
 
             clib.compute_dmi_field_interfacial(m,
                                                self.field,
+                                               self.mu_s_inv,
                                                self.energy,
                                                self.D,
                                                self.neighbours,
@@ -140,7 +142,7 @@ class DMI(Energy):
                                                self.DMI_vector
                                                )
 
-        return self.field * self.mu_s_inv
+        return self.field
 
     def compute_energy_direct(self):
         """

--- a/fidimag/atomistic/dmi.py
+++ b/fidimag/atomistic/dmi.py
@@ -81,8 +81,8 @@ class DMI(Energy):
 
         self.jac = True
 
-    def setup(self, mesh, spin, mu_s):
-        super(DMI, self).setup(mesh, spin, mu_s)
+    def setup(self, mesh, spin, mu_s, mu_s_inv):
+        super(DMI, self).setup(mesh, spin, mu_s, mu_s_inv)
 
         if self.mesh_type == 'hexagonal':
             self.n_ngbs_dmi = 6

--- a/fidimag/atomistic/energy.py
+++ b/fidimag/atomistic/energy.py
@@ -12,7 +12,7 @@ class Energy(object):
 
     """
 
-    def setup(self, mesh, spin, mu_s):
+    def setup(self, mesh, spin, mu_s, mu_s_inv):
         self.mesh = mesh
         self.dx = mesh.dx * mesh.unit_length
         self.dy = mesh.dy * mesh.unit_length
@@ -30,16 +30,8 @@ class Energy(object):
 
         self.field = np.zeros(3 * self.n, dtype=np.float)
         self.energy = np.zeros(mesh.n, dtype=np.float)
-        self.mu_s_inv = np.zeros(3 * self.n, dtype=np.float)
 
-        self.mu_s_inv.shape = (-1, 3)
-        for i in range(mesh.n):
-            if self.mu_s[i] == 0.0:
-                self.mu_s_inv[i, :] = 0
-            else:
-                self.mu_s_inv[i, :] = 1.0 / self.mu_s[i]
-
-        self.mu_s_inv.shape = (-1,)
+        self.mu_s_inv = mu_s_inv
 
         self.xperiodic, self.yperiodic = (mesh.periodicity[0],
                                           mesh.periodicity[1])

--- a/fidimag/atomistic/exchange.py
+++ b/fidimag/atomistic/exchange.py
@@ -86,8 +86,8 @@ class Exchange(Energy):
         self.name = name
         self.jac = False
 
-    def setup(self, mesh, spin, mu_s):
-        super(Exchange, self).setup(mesh, spin, mu_s)
+    def setup(self, mesh, spin, mu_s, mu_s_inv):
+        super(Exchange, self).setup(mesh, spin, mu_s, mu_s_inv)
 
         # Uniform exchange ----------------------------------------------------
         if isinstance(self.J, (int, float)):

--- a/fidimag/atomistic/exchange.py
+++ b/fidimag/atomistic/exchange.py
@@ -128,6 +128,7 @@ class Exchange(Energy):
 
         clib.compute_exchange_field_spatial(m,
                                             self.field,
+                                            self.mu_s_inv,
                                             self.energy,
                                             self._J,
                                             self.neighbours,
@@ -135,7 +136,7 @@ class Exchange(Energy):
                                             self.n_ngbs
                                             )
 
-        return self.field * self.mu_s_inv
+        return self.field
 
     def compute_field_uniform(self, t=0, spin=None):
 
@@ -143,6 +144,7 @@ class Exchange(Energy):
 
         clib.compute_exchange_field(m,
                                     self.field,
+                                    self.mu_s_inv,
                                     self.energy,
                                     self.Jx,
                                     self.Jy,
@@ -152,13 +154,16 @@ class Exchange(Energy):
                                     self.n_ngbs
                                     )
 
-        return self.field * self.mu_s_inv
+        return self.field
 
     def compute_field_full(self, t=0, spin=None):
 
         m = spin if spin is not None else self.spin
 
-        clib.compute_full_exchange_field(m, self.field, self.energy,
+        clib.compute_full_exchange_field(m,
+                                         self.field,
+                                         self.mu_s_inv,
+                                         self.energy,
                                          self._J,
                                          self.neighbours,
                                          self.n, self.mesh.n_ngbs,
@@ -167,7 +172,7 @@ class Exchange(Energy):
                                          self.mesh._sum_ngbs_shell
                                          )
 
-        return self.field * self.mu_s_inv
+        return self.field
 
 
 class UniformExchange(Exchange):

--- a/fidimag/atomistic/lib/clib.h
+++ b/fidimag/atomistic/lib/clib.h
@@ -29,17 +29,20 @@ inline double cross_z(double a0, double a1, double a2, double b0, double b1,
 // ----------------------------------------------------------------------------
 // From exch.c
 
-void compute_exch_field(double *restrict spin, double *restrict field, double *restrict energy, double Jx,
+void compute_exch_field(double *restrict spin, double *restrict field, double *restrict mu_s_inv,
+                        double *restrict energy, double Jx,
                         double Jy, double Jz, int *restrict ngbs, int n, int n_ngbs);
 
-void compute_exch_field_spatial(double *restrict spin, double *restrict field, double *restrict energy,
+void compute_exch_field_spatial(double *restrict spin, double *restrict field, double *restrict mu_s_inv,
+                                double *restrict energy,
                                 double *restrict J, int *restrict ngbs, int n, int n_ngbs);
 
 double compute_exch_energy(double *restrict spin, double Jx, double Jy, double Jz,
                            int nx, int ny, int nz, int xperiodic,
                            int yperiodic);
 
-void compute_full_exch_field(double *restrict spin, double *restrict field, double *restrict energy,
+void compute_full_exch_field(double *restrict spin, double *restrict field, double *restrict mu_s_inv,
+                             double *restrict energy,
 					      	 double *restrict J, int *restrict ngbs, int n, int n_ngbs,
                              int n_shells, int *restrict n_ngbs_shell, int *restrict sum_ngbs_shell
                              );
@@ -47,18 +50,26 @@ void compute_full_exch_field(double *restrict spin, double *restrict field, doub
 // -----------------------------------------------------------------------------
 // From anis.c
 
-void compute_anis(double *restrict spin, double *restrict field, double *restrict energy, double *restrict Ku,
+void compute_anis(double *restrict spin, double *restrict field,
+                  double *restrict mu_s_inv,
+                  double *restrict energy, double *restrict Ku,
                   double *restrict axis, int n);
-void compute_anis_cubic(double *restrict spin, double *restrict field, double *restrict energy,
-	          double *Kc, int n); 
+
+void compute_anis_cubic(double *restrict spin, double *restrict field,
+                        double *restrict mu_s_inv,
+                        double *restrict energy,
+                        double *Kc, int n);
 
 // ----------------------------------------------------------------------------
 // From dmi.c
 
-void dmi_field_bulk(double *restrict spin, double *restrict field, double *restrict energy, double *D,
+void dmi_field_bulk(double *restrict spin, double *restrict field,
+                    double *restrict mu_s_inv,
+                    double *restrict energy, double *D,
                     int *restrict ngbs, int n, int n_ngbs);
 
 void dmi_field_interfacial_atomistic(double *spin, double *field,
+                                     double *mu_s_inv,
                                      double *energy, double D, int *ngbs, int n,
                                      int n_ngbs, int n_ngbs_dmi, double *DMI_vec);
 

--- a/fidimag/atomistic/lib/clib.pyx
+++ b/fidimag/atomistic/lib/clib.pyx
@@ -42,28 +42,34 @@ cdef extern from "clib.h":
 
     # -------------------------------------------------------------------------
 
-    void compute_exch_field(double *spin, double *field, double *energy,
+    void compute_exch_field(double *spin, double *field, double *mu_s_inv,
+                            double *energy,
                             double Jx, double Jy, double Jz,
                             int *ngbs, int n, int n_ngbs)
-    void compute_exch_field_spatial(double *spin, double *field, double *energy,
-                            double *J, int *ngbs, int n, int n_ngbs)
+    void compute_exch_field_spatial(double *spin, double *field, double *mu_s_inv,
+                                    double *energy,
+                                    double *J, int *ngbs, int n, int n_ngbs)
 
     double compute_exch_energy(double *spin, double Jx, double Jy, double Jz,
                                int nx, int ny, int nz,
                                int xperiodic, int yperiodic)
 
-    void compute_full_exch_field(double *spin, double *field, double *energy,
-					      	     double *J, int *ngbs, int n, int n_ngbs,
+    void compute_full_exch_field(double *spin, double *field, double *mu_s_inv,
+                                 double *energy,
+				 double *J, int *ngbs, int n, int n_ngbs,
                                  int n_shells, int *n_ngbs_shell,
                                  int *sum_ngbs_shell
                                  )
 
     # -------------------------------------------------------------------------
 
-    void dmi_field_bulk(double *spin, double *field, double *energy,
+    void dmi_field_bulk(double *spin, double *field,
+                        double *mu_s_inv,
+                        double *energy,
                         double *D, int *ngbs, int n, int n_ngbs)
 
     void dmi_field_interfacial_atomistic(double *spin, double *field,
+                                         double *mu_s_inv,
                                          double *energy, double D, int *ngbs,
                                          int n, int n_ngbs, int n_ngbs_dmi,
                                          double *DMI_vec)
@@ -80,17 +86,21 @@ cdef extern from "clib.h":
 
     # -------------------------------------------------------------------------
 
-    void compute_anis(double *spin, double *field, double *energy,
+    void compute_anis(double *spin, double *field, double *mu_s_inv,
+                      double *energy,
                       double *Ku, double *axis, int n)
 
-    void compute_anis_cubic(double *spin, double *field, double *energy, double *Kc, int n)
+    void compute_anis_cubic(double *spin, double *field, double *mu_s_inv,
+                            double *energy, double *Kc, int n)
 
     # -------------------------------------------------------------------------
 
     void normalise(double *m, int *pins, int n)
 
     # used for sllg
-    void llg_rhs_dw_c(double *m, double *h, double *dm, double *T, double *alpha, double *mu_s_inv, int *pins, double *eta, int n, double gamma, double dt)
+    void llg_rhs_dw_c(double *m, double *h, double *dm, double *T, double *alpha,
+                      double *mu_s_inv, int *pins, double *eta, int n,
+                      double gamma, double dt)
 
 
 
@@ -143,23 +153,27 @@ def compute_px_py(double [:] spin,
 
 def compute_exchange_field(double [:] spin,
                            double [:] field,
+                           double [:] mu_s_inv,
                            double [:] energy,
                            Jx, Jy, Jz,
                            int [:, :] ngbs,
                            n, n_ngbs
                            ):
 
-    compute_exch_field(&spin[0], &field[0], &energy[0], Jx, Jy, Jz,
+    compute_exch_field(&spin[0], &field[0], &mu_s_inv[0],
+                       &energy[0], Jx, Jy, Jz,
                        &ngbs[0, 0], n, n_ngbs)
 
 def compute_exchange_field_spatial(double [:] spin,
                                    double [:] field,
+                                   double [:] mu_s_inv,
                                    double [:] energy,
                                    double [:, :] J,
                                    int [:, :] ngbs,
                                    n, n_ngbs):
 
-    compute_exch_field_spatial(&spin[0], &field[0], &energy[0],&J[0,0],&ngbs[0, 0], n, n_ngbs)
+    compute_exch_field_spatial(&spin[0], &field[0], &mu_s_inv[0],
+                               &energy[0],&J[0,0],&ngbs[0, 0], n, n_ngbs)
 
 
 def compute_exchange_energy(double [:] spin,
@@ -172,6 +186,7 @@ def compute_exchange_energy(double [:] spin,
 
 def compute_full_exchange_field(double [:] spin,
                                 double [:] field,
+                                double [:] mu_s_inv,
                                 double [:] energy,
                                 double [:] J,
                                 int [:, :] ngbs,
@@ -180,40 +195,54 @@ def compute_full_exchange_field(double [:] spin,
                                 int [:] sum_ngbs_shell
                                 ):
 
-    compute_full_exch_field(&spin[0], &field[0], &energy[0], &J[0],
+    compute_full_exch_field(&spin[0], &field[0], &mu_s_inv[0],
+                            &energy[0], &J[0],
                             &ngbs[0, 0], n, n_ngbs, n_shells,
                             &n_ngbs_shell[0], &sum_ngbs_shell[0])
 
 # -------------------------------------------------------------------------
 
-def compute_anisotropy(double [:] spin, double [:] field, double [:] energy,
+def compute_anisotropy(double [:] spin, double [:] field,
+                       double [:] mu_s_inv,
+                       double [:] energy,
                        double [:] Ku, double [:] axis, n):
-    compute_anis(&spin[0], &field[0], &energy[0], &Ku[0], &axis[0], n)
+    compute_anis(&spin[0], &field[0], &mu_s_inv[0],
+                 &energy[0], &Ku[0], &axis[0], n)
 
-def compute_anisotropy_cubic(double [:] spin, double [:] field, double [:] energy,
+def compute_anisotropy_cubic(double [:] spin, double [:] field,
+                             double [:] mu_s_inv,
+                             double [:] energy,
                              double [:] Kc, n):
-    compute_anis_cubic(&spin[0], &field[0], &energy[0], &Kc[0], n)
+
+    compute_anis_cubic(&spin[0], &field[0], &mu_s_inv[0],
+                       &energy[0], &Kc[0], n)
 
 # -----------------------------------------------------------------------------
 
 def compute_dmi_field(double [:] spin,
                       double [:] field,
+                      double [:] mu_s_inv,
                       double [:] energy,
                       double [:, :] D,
                       int [:, :] ngbs,
                       n, n_ngbs):
-    dmi_field_bulk(&spin[0], &field[0], &energy[0], &D[0,0], &ngbs[0, 0], n, n_ngbs)
+    dmi_field_bulk(&spin[0], &field[0],
+                   &mu_s_inv[0], &energy[0], &D[0,0],
+                   &ngbs[0, 0], n, n_ngbs)
 
 
 def compute_dmi_field_interfacial(double [:] spin,
                                   double [:] field,
+                                  double [:] mu_s_inv,
                                   double [:] energy,
                                   D,
                                   int [:, :] ngbs,
                                   n, n_ngbs, n_ngbs_dmi,
                                   double [:] DMI_vec,
                                   ):
-    dmi_field_interfacial_atomistic(&spin[0], &field[0], &energy[0],
+    dmi_field_interfacial_atomistic(&spin[0], &field[0],
+                                    &mu_s_inv[0],
+                                    &energy[0],
                                     D, &ngbs[0, 0], n,
                                     n_ngbs, n_ngbs_dmi,
                                     &DMI_vec[0]
@@ -251,7 +280,8 @@ def compute_llg_rhs_dw(double [:] dm,
                        double [:] mu_s_inv,
                        double [:] eta,
                        int [:] pin, n, gamma, dt):
-    llg_rhs_dw_c(&spin[0], &field[0], &dm[0], &T[0], &alpha[0],  &mu_s_inv[0], &pin[0], &eta[0], n, gamma, dt)
+    llg_rhs_dw_c(&spin[0], &field[0], &dm[0], &T[0], &alpha[0], 
+                 &mu_s_inv[0], &pin[0], &eta[0], n, gamma, dt)
 
 
 # -----------------------------------------------------------------------------

--- a/fidimag/atomistic/lib/dmi.c
+++ b/fidimag/atomistic/lib/dmi.c
@@ -28,7 +28,9 @@ boundaries
 */
 
 void dmi_field_bulk(double *restrict spin, double *restrict field,
-                    double *restrict energy, double *restrict _D, int *restrict ngbs, int nxyz, int n_ngbs) {
+                    double *restrict mu_s_inv,
+                    double *restrict energy, double *restrict _D,
+                    int *restrict ngbs, int nxyz, int n_ngbs) {
 
     /* Bulk DMI field and energy computation
      *
@@ -101,7 +103,7 @@ void dmi_field_bulk(double *restrict spin, double *restrict field,
             }
         }
 
-		field[3 * i] = fx;
+		field[3 * i]     = fx;
         field[3 * i + 1] = fy;
         field[3 * i + 2] = fz;
 
@@ -109,11 +111,20 @@ void dmi_field_bulk(double *restrict spin, double *restrict field,
                             fy * spin[3 * i + 1] +
                             fz * spin[3 * i + 2]
                             );
+
+        // Scale field by 1/mu_s
+		field[3 * i]     *= mu_s_inv[i];
+		field[3 * i + 1] *= mu_s_inv[i];
+		field[3 * i + 2] *= mu_s_inv[i];
     }
 }
 
-void dmi_field_interfacial_atomistic(double *restrict spin, double *restrict field, double *restrict energy,
-    double D, int *restrict ngbs, int n, int n_ngbs, int n_ngbs_dmi, double *restrict DMI_vec) {
+void dmi_field_interfacial_atomistic(double *restrict spin, double *restrict field,
+                                     double *restrict mu_s_inv,
+                                     double *restrict energy,
+                                     double D, int *restrict ngbs, int n,
+                                     int n_ngbs, int n_ngbs_dmi,
+                                     double *restrict DMI_vec) {
     
     /* Interfacial DMI field and energy computation
      *
@@ -188,16 +199,21 @@ void dmi_field_interfacial_atomistic(double *restrict spin, double *restrict fie
             }
         }
 
-        field[3 * i] = fx;
+        field[3 * i]     = fx;
   	    field[3 * i + 1] = fy;
   	    field[3 * i + 2] = fz;
 
         // TODO: check whether the energy is correct or not.
         /* Avoid second counting with 1/2 */
   	    energy[i] = -0.5 * (fx * spin[3 * i] +
-                            fy * spin[3 * i + 1]+
+                            fy * spin[3 * i + 1] +
                             fz * spin[3 * i + 2]
                             );
+
+        // Scale field by 1/mu_s
+		field[3 * i]     *= mu_s_inv[i];
+		field[3 * i + 1] *= mu_s_inv[i];
+		field[3 * i + 2] *= mu_s_inv[i];
     }
 }
 

--- a/fidimag/atomistic/lib/exch.c
+++ b/fidimag/atomistic/lib/exch.c
@@ -2,13 +2,13 @@
 
 /*
  compute the effective exchange field at site i
- 
+
  H_i = J \sum_<i,j> S_j
- 
+
  with Hamiltonian
- 
+
  Hamiltonian = - J \sum_<i,j> S_i \cdot S_j
- 
+
  Note that the pair <i,j> only run once for each pair.
 
 - NEIGHBOURS in the arguments:
@@ -21,7 +21,7 @@ the following order:
 for every spin. It is -1 for boundaries.  The array is like:
 
                                       __here are next neighbour indexes
-                                      | 
+                                      |
      | 0-x, 0+x, 0-y, 0+y, 0-z, 0+z, ... 1-x, 1+x, 1-y, ...  |
        i=0                               i=1                ...
 
@@ -35,23 +35,25 @@ The ngbs array also gives the correct indexes for the spins at periodic
 boundaries
 
  */
-void compute_exch_field(double *restrict spin, double *restrict field, double *restrict energy,
+void compute_exch_field(double *restrict spin, double *restrict field,
+                        double *restrict mu_s_inv,
+                        double *restrict energy,
 						double Jx, double Jy, double Jz,
                         int *restrict ngbs, int n, int n_ngbs) {
-    
+
     #pragma omp parallel for
 	for (int i = 0; i < n; i++) {
 
 		int id = 0;
 		int id_nn = n_ngbs * i; // index for the neighbours
-		
+
 		double fx = 0, fy = 0, fz = 0;
 
         for (int j = 0; j < 6; j++) {
-            
+
             if (ngbs[id_nn + j] >= 0) {
 
-                id = 3 * ngbs[id_nn + j]; 
+                id = 3 * ngbs[id_nn + j];
                 fx += Jx * spin[id];
                 fy += Jy * spin[id + 1];
                 fz += Jz * spin[id + 2];
@@ -62,23 +64,29 @@ void compute_exch_field(double *restrict spin, double *restrict field, double *r
         field[3 * i] = fx;
         field[3 * i + 1] = fy;
         field[3 * i + 2] = fz;
-        energy[i] = -0.5 * (fx * spin[3 * i] + fy * spin[3 * i + 1] + 
+        energy[i] = -0.5 * (fx * spin[3 * i] + fy * spin[3 * i + 1] +
                             fz * spin[3 * i + 2]);
+
+        // Scale the field to 1/mu_s
+        field[3 * i]     *= mu_s_inv[i];
+        field[3 * i + 1] *= mu_s_inv[i];
+        field[3 * i + 2] *= mu_s_inv[i];
     }
 }
 
 
 
-double compute_exch_energy(double *restrict spin, double Jx,  double Jy, double Jz,
-			int nx, int ny, int nz, int xperiodic, int yperiodic) {
-    
+double compute_exch_energy(double *restrict spin,
+                           double Jx,  double Jy, double Jz,
+                           int nx, int ny, int nz, int xperiodic, int yperiodic) {
+
 	int nyz = ny * nz;
 	int n1 = nx * nyz, n2 = 2 * n1;
 	int i, j, k;
 	int index, id;
 	double Sx, Sy, Sz;
 	double energy = 0;
-    
+
 	for (i = 0; i < nx; i++) {
         for (j = 0; j < ny; j++) {
             for (k = 0; k < nz; k++) {
@@ -86,7 +94,7 @@ double compute_exch_energy(double *restrict spin, double Jx,  double Jy, double 
                 Sx = spin[index];
                 Sy = spin[index + n1];
                 Sz = spin[index + n2];
-                
+
                 if (i < nx - 1 || xperiodic) {
                     id = index + nyz;
                     if (i == nx-1){
@@ -96,7 +104,7 @@ double compute_exch_energy(double *restrict spin, double Jx,  double Jy, double 
                     energy += Jy * Sy * spin[id + n1];
                     energy += Jz * Sz * spin[id + n2];
                 }
-                
+
                 if (j < ny - 1 || yperiodic) {
                     id = index + nz;
                     if (j == ny-1){
@@ -106,55 +114,58 @@ double compute_exch_energy(double *restrict spin, double Jx,  double Jy, double 
                     energy += Jy * Sy * spin[id + n1];
                     energy += Jz * Sz * spin[id + n2];
                 }
-                
+
                 if (k < nz - 1) {
                     id = index + 1;
                     energy += Jx * Sx * spin[id];
                     energy += Jy * Sy * spin[id + n1];
                     energy += Jz * Sz * spin[id + n2];
                 }
-                
+
             }
         }
 	}
-    
+
 	energy = -energy;
-    
+
 	return energy;
-    
+
 }
 
 
 /*
  compute the effective exchange field at site i
- 
+
  H_i =  \sum_<i,j> J_{ij} S_j
- 
+
  with Hamiltonian
- 
+
  Hamiltonian = - \sum_<i,j> J_{ij} S_i \cdot S_j
- 
+
  Note that the pair <i,j> only run once for each pair.
- 
+
  */
-void compute_exch_field_spatial(double *restrict spin, double *restrict field, double *restrict energy,
-				double *restrict J, int *restrict ngbs, int n, int n_ngbs) {
-    
+void compute_exch_field_spatial(double *restrict spin, double *restrict field,
+                                double *restrict mu_s_inv,
+                                double *restrict energy,
+                                double *restrict J, int *restrict ngbs,
+                                int n, int n_ngbs) {
+
     #pragma omp parallel for
 	for (int i = 0; i < n; i++) {
 
 		int id = 0;
 		int id_nn = n_ngbs * i; // index for the neighbours
-		
+
 		double fx = 0, fy = 0, fz = 0;
 
         for (int j = 0; j < 6; j++) {
-            
+
             int p = id_nn + j;
-            
+
             if (ngbs[p] >= 0) {
 
-                id = 3 * ngbs[p]; 
+                id = 3 * ngbs[p];
                 fx += J[p] * spin[id];
                 fy += J[p] * spin[id + 1];
                 fz += J[p] * spin[id + 2];
@@ -165,8 +176,13 @@ void compute_exch_field_spatial(double *restrict spin, double *restrict field, d
         field[3 * i] = fx;
         field[3 * i + 1] = fy;
         field[3 * i + 2] = fz;
-        energy[i] = -0.5 * (fx * spin[3 * i] + fy * spin[3 * i + 1] + 
+        energy[i] = -0.5 * (fx * spin[3 * i] + fy * spin[3 * i + 1] +
                             fz * spin[3 * i + 2]);
+
+        // Scale the field to 1/mu_s
+        field[3 * i]     *= mu_s_inv[i];
+        field[3 * i + 1] *= mu_s_inv[i];
+        field[3 * i + 2] *= mu_s_inv[i];
     }
 }
 
@@ -179,17 +195,20 @@ void compute_exch_field_spatial(double *restrict spin, double *restrict field, d
  * n_ngbs           :: number of neighbours per lattice site
  * n_shells         :: number of specified shells of neighbours
  * n_ngbs_shell     :: number of neighbours per shell. First element is zero.
- *                     For a hex lattice, this array is: [0, 6, 6, 12, ... ] 
+ *                     For a hex lattice, this array is: [0, 6, 6, 12, ... ]
  * sum_ngbs_shell   :: sum of number of neighbours up to the i-th shell to
  *                     locate the column position for the ngbs of a specific shell.
  *                     First element is zero.
  *                     For a hex lattice, this array is: [0, 6, 12, 24, ...]
- *                     Thus, we can locate ngbs from cols 0-5, 6-11, 12, 23, ... etc 
+ *                     Thus, we can locate ngbs from cols 0-5, 6-11, 12, 23, ... etc
  *
  */
-void compute_full_exch_field(double *restrict spin, double *restrict field, double *restrict energy,
+void compute_full_exch_field(double *restrict spin, double *restrict field,
+                             double *restrict mu_s_inv,
+                             double *restrict energy,
 					      	 double J[9], int *ngbs, int n, int n_ngbs,
-                             int n_shells, int *restrict n_ngbs_shell, int *restrict sum_ngbs_shell
+                             int n_shells, int *restrict n_ngbs_shell,
+                             int *restrict sum_ngbs_shell
                              ) {
 
     #pragma omp parallel for
@@ -197,15 +216,15 @@ void compute_full_exch_field(double *restrict spin, double *restrict field, doub
 
 		int id = 0;
 		int id_ngbs = n_ngbs * i; // index for the starting point of neighbours
-		
+
 		double fx = 0, fy = 0, fz = 0;
 
         for (int sh = 1; sh < n_shells + 1; sh++) {
             for (int j = sum_ngbs_shell[sh - 1]; j < sum_ngbs_shell[sh]; j++) {
-                
+
                 if (ngbs[id_ngbs + j] >= 0) {
 
-                    id = 3 * ngbs[id_ngbs + j]; 
+                    id = 3 * ngbs[id_ngbs + j];
                     fx += J[sh - 1] * spin[id];
                     fy += J[sh - 1] * spin[id + 1];
                     fz += J[sh - 1] * spin[id + 2];
@@ -217,7 +236,12 @@ void compute_full_exch_field(double *restrict spin, double *restrict field, doub
         field[3 * i] = fx;
         field[3 * i + 1] = fy;
         field[3 * i + 2] = fz;
-        energy[i] = -0.5 * (fx * spin[3 * i] + fy * spin[3 * i + 1] + 
+        energy[i] = -0.5 * (fx * spin[3 * i] + fy * spin[3 * i + 1] +
                             fz * spin[3 * i + 2]);
+
+        // Scale the field to 1/mu_s
+        field[3 * i]     *= mu_s_inv[i];
+        field[3 * i + 1] *= mu_s_inv[i];
+        field[3 * i + 2] *= mu_s_inv[i];
     }
 }

--- a/fidimag/atomistic/sim.py
+++ b/fidimag/atomistic/sim.py
@@ -161,12 +161,10 @@ class Sim(SimBase):
 
         self._mu_s[:] = helper.init_scalar(value, self.mesh)
         nonzero = 0
-        self._mu_s_inv.shape = (-1, 3)
         for i in range(self.n):
             if self._mu_s[i] > 0.0:
                 self._mu_s_inv[i] = 1.0 / self._mu_s[i]
                 nonzero += 1
-        self._mu_s_inv.shape = (-1,)
 
         # We moved this variable to the micro_driver class
         self.n_nonzero = nonzero

--- a/fidimag/atomistic/zeeman.py
+++ b/fidimag/atomistic/zeeman.py
@@ -58,7 +58,7 @@ class Zeeman(object):
         self.name = name
         self.jac = False
 
-    def setup(self, mesh, spin, mu_s):
+    def setup(self, mesh, spin, mu_s, mu_s_inv):
         self.mesh = mesh
         self.spin = spin
         self.n = mesh.n

--- a/fidimag/common/sim_base.py
+++ b/fidimag/common/sim_base.py
@@ -21,9 +21,8 @@ class SimBase(object):
         self.unit_length = mesh.unit_length
 
         self._magnetisation = np.zeros(self.n, dtype=np.float)
-        # This array is the 1/mu_s factor which we use to multiply vector field
-        # arrays, thus we set up with 3 * n elements to avoid multiple reshaping
-        self._magnetisation_inv = np.zeros(3 * self.n, dtype=np.float)
+        # Inverse magnetisation
+        self._magnetisation_inv = np.zeros(self.n, dtype=np.float)
 
         self.spin = np.ones(3 * self.n, dtype=np.float)
         self._pins = np.zeros(self.n, dtype=np.int32)

--- a/fidimag/common/sim_base.py
+++ b/fidimag/common/sim_base.py
@@ -21,6 +21,10 @@ class SimBase(object):
         self.unit_length = mesh.unit_length
 
         self._magnetisation = np.zeros(self.n, dtype=np.float)
+        # This array is the 1/mu_s factor which we use to multiply vector field
+        # arrays, thus we set up with 3 * n elements to avoid multiple reshaping
+        self._magnetisation_inv = np.zeros(3 * self.n, dtype=np.float)
+
         self.spin = np.ones(3 * self.n, dtype=np.float)
         self._pins = np.zeros(self.n, dtype=np.int32)
         self.field = np.zeros(3 * self.n, dtype=np.float)
@@ -170,7 +174,8 @@ class SimBase(object):
         # magnetisation is Ms for the micromagnetic Sim class, and it is
         # mu_s for the atomistic Sim class
         interaction.setup(self.mesh, self.spin,
-                          self._magnetisation
+                          self._magnetisation,
+                          self._magnetisation_inv
                           )
 
         # TODO: FIX  --> ??

--- a/fidimag/micro/anisotropy.py
+++ b/fidimag/micro/anisotropy.py
@@ -17,8 +17,8 @@ class UniaxialAnisotropy(Energy):
         self.jac = True
         self.axis = axis
 
-    def setup(self, mesh, spin, Ms):
-        super(UniaxialAnisotropy, self).setup(mesh, spin, Ms)
+    def setup(self, mesh, spin, Ms, Ms_inv):
+        super(UniaxialAnisotropy, self).setup(mesh, spin, Ms, Ms_inv)
 
         self._Ku = helper.init_scalar(self.Ku, self.mesh)
         self._axis = helper.init_vector(self.axis, self.mesh, True)

--- a/fidimag/micro/demag.py
+++ b/fidimag/micro/demag.py
@@ -23,7 +23,7 @@ class Demag(object):
         self.pbc_options = pbc_options
         self.jac = False
 
-    def setup(self, mesh, spin, Ms):
+    def setup(self, mesh, spin, Ms, Ms_inv):
         self.mesh = mesh
         self.dx = mesh.dx
         self.dy = mesh.dy

--- a/fidimag/micro/demag.py
+++ b/fidimag/micro/demag.py
@@ -1,6 +1,7 @@
 import fidimag.extensions.dipolar as clib
 import numpy as np
 import os
+from .energy import Energy
 
 mu_0 = 4 * np.pi * 1e-7
 
@@ -13,7 +14,7 @@ default_options={
 }
 
 
-class Demag(object):
+class Demag(Energy):
 
     def __init__(self, name='Demag', pbc_2d=False,
                  pbc_options=default_options):
@@ -24,17 +25,7 @@ class Demag(object):
         self.jac = False
 
     def setup(self, mesh, spin, Ms, Ms_inv):
-        self.mesh = mesh
-        self.dx = mesh.dx
-        self.dy = mesh.dy
-        self.dz = mesh.dz
-        self.nx = mesh.nx
-        self.ny = mesh.ny
-        self.nz = mesh.nz
-        self.spin = spin
-        self.field = np.zeros(3 * mesh.n, dtype=np.float)
-
-        self.Ms = Ms
+        super(Demag, self).setup(mesh, spin, Ms, Ms_inv)
 
         if self.pbc_2d is True:
 
@@ -91,7 +82,7 @@ class Demag(object):
 
         else:
             self.demag = clib.FFTDemag(self.dx, self.dy, self.dz,
-                                       self.nx, self.ny, self.nz, 
+                                       self.nx, self.ny, self.nz,
                                        tensor_type='demag')
 
 

--- a/fidimag/micro/dmi.py
+++ b/fidimag/micro/dmi.py
@@ -98,8 +98,8 @@ class DMI(Energy):
                 "'bulk', 'interfacial', 'D_2d'."
                 )
 
-    def setup(self, mesh, spin, Ms):
-        super(DMI, self).setup(mesh, spin, Ms)
+    def setup(self, mesh, spin, Ms, Ms_inv):
+        super(DMI, self).setup(mesh, spin, Ms, Ms_inv)
 
         # We will allow to completely specify the DMI vectors according to the
         # NNs of every lattice site, thus we need a matrix of n_dmi_ngbs * n entries

--- a/fidimag/micro/energy.py
+++ b/fidimag/micro/energy.py
@@ -7,7 +7,7 @@ class Energy(object):
     An abstract class to implement the basic functions such as setup in micromagnetics.
     """
 
-    def setup(self, mesh, spin, Ms):
+    def setup(self, mesh, spin, Ms, Ms_inv):
         self.mesh = mesh
         self.dx = mesh.dx * mesh.unit_length
         self.dy = mesh.dy * mesh.unit_length
@@ -22,13 +22,7 @@ class Energy(object):
         self.energy = np.zeros(mesh.n)
         self.total_energy = 0
         self.Ms = Ms
-        self.Ms_inv = np.zeros(mesh.n)
-
-        for i in range(mesh.n):
-            if self.Ms[i] == 0.0:
-                self.Ms_inv[i] = 0
-            else:
-                self.Ms_inv[i] = 1.0 / self.Ms[i]
+        self.Ms_inv = Ms_inv
 
         # For old code compatibility
         self.xperiodic, self.yperiodic, self.zperiodic = mesh.periodicity

--- a/fidimag/micro/exchange_rkky.py
+++ b/fidimag/micro/exchange_rkky.py
@@ -34,8 +34,8 @@ class ExchangeRKKY(Energy):
         self.z_top = z_top
         self.jac = True
 
-    def setup(self, mesh, spin, Ms):
-        super(ExchangeRKKY, self).setup(mesh, spin, Ms)
+    def setup(self, mesh, spin, Ms, Ms_inv):
+        super(ExchangeRKKY, self).setup(mesh, spin, Ms, Ms_inv)
         if self.z_top<0:
             self.z_top+= self.nz
  

--- a/fidimag/micro/lib/exch.c
+++ b/fidimag/micro/lib/exch.c
@@ -10,6 +10,7 @@ void compute_exch_field_micro(double *restrict m, double *restrict field, double
      *
      * Ms_inv     :: Array with the (1 / Ms) values for every mesh node.
      *               The values are zero for points with Ms = 0 (no material)
+     *               The array has size 3 * n (to multiply fields using Numpy)
      *
      * A          :: Exchange constant
      *
@@ -95,7 +96,7 @@ void compute_exch_field_micro(double *restrict m, double *restrict field, double
 	    int idn = 6 * i; // index for the neighbours
 
         /* Set a zero field for sites without magnetic material */
-	    if (Ms_inv[i] == 0.0){
+	    if (Ms_inv[3 * i] == 0.0){
 	        field[3 * i] = 0;
 	        field[3 * i + 1] = 0;
 	        field[3 * i + 2] = 0;
@@ -112,7 +113,7 @@ void compute_exch_field_micro(double *restrict m, double *restrict field, double
 
                 /* Check that the magnetisation of the neighbouring spin
                  * is larger than zero */
-                if (Ms_inv[ngbs[idn + j]] > 0){
+                if (Ms_inv[3 * ngbs[idn + j]] > 0){
 
                     /* Neighbours in the -x and +x directions
                      * giving: ( m[i-x] - m[i] ) + ( m[i+x] - m[i] )
@@ -155,9 +156,9 @@ void compute_exch_field_micro(double *restrict m, double *restrict field, double
                             + fz * m[3 * i + 2]);
 
         /* Update the field H_ex which has the same structure than *m */
-        field[3 * i]     = fx * Ms_inv[i] * MU0_INV;
-        field[3 * i + 1] = fy * Ms_inv[i] * MU0_INV;
-        field[3 * i + 2] = fz * Ms_inv[i] * MU0_INV;
+        field[3 * i]     = fx * Ms_inv[3 * i] * MU0_INV;
+        field[3 * i + 1] = fy * Ms_inv[3 * i] * MU0_INV;
+        field[3 * i + 2] = fz * Ms_inv[3 * i] * MU0_INV;
     }
 }
 
@@ -174,6 +175,7 @@ void compute_exch_field_rkky_micro(double *m, double *field, double *energy, dou
      *
      * Ms_inv     :: Array with the (1 / Ms) values for every mesh node.
      *               The values are zero for points with Ms = 0 (no material)
+     *               The array has size 3 * n ! (as a field)
      *
      * sigma          :: Exchange constant
      *
@@ -216,18 +218,18 @@ void compute_exch_field_rkky_micro(double *m, double *field, double *energy, dou
 				 mby = m[3*id1+1];
 				 mbz = m[3*id1+2];
 
-				 if (Ms_inv[id1] != 0.0){
+				 if (Ms_inv[3 * id1] != 0.0){
 					 energy[id1]  = sigma*(1-mtx*mbx-mty*mby-mtz*mbz);
-					 field[3*id1]   = sigma * mtx * Ms_inv[id1] * MU0_INV;
-					 field[3*id1+1] = sigma * mty * Ms_inv[id1] * MU0_INV;
-					 field[3*id1+2] = sigma * mtz * Ms_inv[id1] * MU0_INV;
+					 field[3*id1]   = sigma * mtx * Ms_inv[3 * id1] * MU0_INV;
+					 field[3*id1+1] = sigma * mty * Ms_inv[3 * id1] * MU0_INV;
+					 field[3*id1+2] = sigma * mtz * Ms_inv[3 * id1] * MU0_INV;
 				 }
 
-				 if (Ms_inv[id2] != 0.0){
+				 if (Ms_inv[3 * id2] != 0.0){
 					 energy[id2]  = sigma*(1-mtx*mbx-mty*mby-mtz*mbz);
-					 field[3*id2]   = sigma * mbx * Ms_inv[id2] * MU0_INV;
-					 field[3*id2+1] = sigma * mby * Ms_inv[id2] * MU0_INV;
-					 field[3*id2+2] = sigma * mbz * Ms_inv[id2] * MU0_INV;
+					 field[3*id2]   = sigma * mbx * Ms_inv[3 * id2] * MU0_INV;
+					 field[3*id2+1] = sigma * mby * Ms_inv[3 * id2] * MU0_INV;
+					 field[3*id2+2] = sigma * mbz * Ms_inv[3 * id2] * MU0_INV;
 				 }
 			 }
 		 }

--- a/fidimag/micro/lib/exch.c
+++ b/fidimag/micro/lib/exch.c
@@ -10,7 +10,6 @@ void compute_exch_field_micro(double *restrict m, double *restrict field, double
      *
      * Ms_inv     :: Array with the (1 / Ms) values for every mesh node.
      *               The values are zero for points with Ms = 0 (no material)
-     *               The array has size 3 * n (to multiply fields using Numpy)
      *
      * A          :: Exchange constant
      *
@@ -96,7 +95,7 @@ void compute_exch_field_micro(double *restrict m, double *restrict field, double
 	    int idn = 6 * i; // index for the neighbours
 
         /* Set a zero field for sites without magnetic material */
-	    if (Ms_inv[3 * i] == 0.0){
+	    if (Ms_inv[i] == 0.0){
 	        field[3 * i] = 0;
 	        field[3 * i + 1] = 0;
 	        field[3 * i + 2] = 0;
@@ -113,7 +112,7 @@ void compute_exch_field_micro(double *restrict m, double *restrict field, double
 
                 /* Check that the magnetisation of the neighbouring spin
                  * is larger than zero */
-                if (Ms_inv[3 * ngbs[idn + j]] > 0){
+                if (Ms_inv[ngbs[idn + j]] > 0){
 
                     /* Neighbours in the -x and +x directions
                      * giving: ( m[i-x] - m[i] ) + ( m[i+x] - m[i] )
@@ -156,9 +155,9 @@ void compute_exch_field_micro(double *restrict m, double *restrict field, double
                             + fz * m[3 * i + 2]);
 
         /* Update the field H_ex which has the same structure than *m */
-        field[3 * i]     = fx * Ms_inv[3 * i] * MU0_INV;
-        field[3 * i + 1] = fy * Ms_inv[3 * i] * MU0_INV;
-        field[3 * i + 2] = fz * Ms_inv[3 * i] * MU0_INV;
+        field[3 * i]     = fx * Ms_inv[i] * MU0_INV;
+        field[3 * i + 1] = fy * Ms_inv[i] * MU0_INV;
+        field[3 * i + 2] = fz * Ms_inv[i] * MU0_INV;
     }
 }
 
@@ -175,7 +174,6 @@ void compute_exch_field_rkky_micro(double *m, double *field, double *energy, dou
      *
      * Ms_inv     :: Array with the (1 / Ms) values for every mesh node.
      *               The values are zero for points with Ms = 0 (no material)
-     *               The array has size 3 * n ! (as a field)
      *
      * sigma          :: Exchange constant
      *
@@ -218,18 +216,18 @@ void compute_exch_field_rkky_micro(double *m, double *field, double *energy, dou
 				 mby = m[3*id1+1];
 				 mbz = m[3*id1+2];
 
-				 if (Ms_inv[3 * id1] != 0.0){
+				 if (Ms_inv[id1] != 0.0){
 					 energy[id1]  = sigma*(1-mtx*mbx-mty*mby-mtz*mbz);
-					 field[3*id1]   = sigma * mtx * Ms_inv[3 * id1] * MU0_INV;
-					 field[3*id1+1] = sigma * mty * Ms_inv[3 * id1] * MU0_INV;
-					 field[3*id1+2] = sigma * mtz * Ms_inv[3 * id1] * MU0_INV;
+					 field[3*id1]   = sigma * mtx * Ms_inv[id1] * MU0_INV;
+					 field[3*id1+1] = sigma * mty * Ms_inv[id1] * MU0_INV;
+					 field[3*id1+2] = sigma * mtz * Ms_inv[id1] * MU0_INV;
 				 }
 
-				 if (Ms_inv[3 * id2] != 0.0){
+				 if (Ms_inv[id2] != 0.0){
 					 energy[id2]  = sigma*(1-mtx*mbx-mty*mby-mtz*mbz);
-					 field[3*id2]   = sigma * mbx * Ms_inv[3 * id2] * MU0_INV;
-					 field[3*id2+1] = sigma * mby * Ms_inv[3 * id2] * MU0_INV;
-					 field[3*id2+2] = sigma * mbz * Ms_inv[3 * id2] * MU0_INV;
+					 field[3*id2]   = sigma * mbx * Ms_inv[id2] * MU0_INV;
+					 field[3*id2+1] = sigma * mby * Ms_inv[id2] * MU0_INV;
+					 field[3*id2+2] = sigma * mbz * Ms_inv[id2] * MU0_INV;
 				 }
 			 }
 		 }

--- a/fidimag/micro/sim.py
+++ b/fidimag/micro/sim.py
@@ -152,12 +152,10 @@ class Sim(SimBase):
 
         self._Ms[:] = helper.init_scalar(value, self.mesh)
         nonzero = 0
-        self._Ms_inv.shape = (-1, 3)
         for i in range(self.n):
             if self._Ms[i] > 0.0:
                 self._Ms_inv[i] = 1.0 / self._Ms[i]
                 nonzero += 1
-        self._Ms_inv.shape = (-1,)
 
         # We moved this variable to the micro_driver class
         self.driver.n_nonzero = nonzero

--- a/fidimag/micro/sim.py
+++ b/fidimag/micro/sim.py
@@ -67,8 +67,10 @@ class Sim(SimBase):
 
         # Saturation magnetisation definitions:
         # self._Ms = np.zeros(self.n, dtype=np.float)
+        # David: be careful to change these references to the common mag array
         self._Ms = self._magnetisation
-        self._Ms_inv = np.zeros(self.n, dtype=np.float)
+        # Remember this is a 3 * n array:
+        self._Ms_inv = self._magnetisation_inv
 
         # Here we link one of the drivers to evolve the LLG equation
         if driver not in KNOWN_DRIVERS:
@@ -150,10 +152,12 @@ class Sim(SimBase):
 
         self._Ms[:] = helper.init_scalar(value, self.mesh)
         nonzero = 0
+        self._Ms_inv.shape = (-1, 3)
         for i in range(self.n):
             if self._Ms[i] > 0.0:
                 self._Ms_inv[i] = 1.0 / self._Ms[i]
                 nonzero += 1
+        self._Ms_inv.shape = (-1,)
 
         # We moved this variable to the micro_driver class
         self.driver.n_nonzero = nonzero

--- a/fidimag/micro/simple_demag.py
+++ b/fidimag/micro/simple_demag.py
@@ -1,7 +1,8 @@
 import numpy as np
+from .energy import Energy
 
 
-class SimpleDemag(object):
+class SimpleDemag(Energy):
     """
     Demagnetising field for thin films in the i-direction.
     Hj = Hk = 0 and Hi = - Mi.
@@ -12,28 +13,11 @@ class SimpleDemag(object):
         field_strength is Ms by default
 
         """
-        
+
         self.Nx = Nx
         self.Ny = Ny
         self.Nz = Nz
-        
         self.name = name
-
-    def setup(self, mesh, spin, Ms):
-        self.mesh = mesh
-        self.spin = spin
-        self.n = mesh.n
-
-        self.Ms = Ms
-        self.Ms_long = np.zeros(3 * mesh.n)
-
-        self.Ms_long.shape = (3, -1)
-        for i in range(mesh.n):
-            self.Ms_long[:, i] = Ms[i]
-
-        self.Ms_long.shape = (-1,)
-        self.field = np.zeros(3 * self.n)
-        #self.field[:] = helper.init_vector(self.H0, self.mesh)
 
 
     def compute_field(self, t=0):
@@ -49,9 +33,7 @@ class SimpleDemag(object):
     def compute_energy(self):
 
         mu_0 = 4*np.pi*1e-7
-
-        sf = 0.5* self.field * self.spin * self.Ms_long * mu_0
-
-        energy = -np.sum(sf)
+        sf = -0.5 * self.field * self.spin * mu_0
+        energy = np.sum(sf.reshape(-1, 3), axis=1) * self.Ms
 
         return energy * self.mesh.cellsize

--- a/fidimag/micro/zeeman.py
+++ b/fidimag/micro/zeeman.py
@@ -64,7 +64,7 @@ class Zeeman(object):
         self.name = name
         self.jac = False
 
-    def setup(self, mesh, spin, Ms):
+    def setup(self, mesh, spin, Ms, Ms_inv):
         self.mesh = mesh
         self.spin = spin
         self.n = mesh.n
@@ -118,8 +118,8 @@ class TimeZeeman(Zeeman):
         self.jac = True
         self.extra_args = extra_args
 
-    def setup(self, mesh, spin, Ms):
-        super(TimeZeeman, self).setup(mesh, spin, Ms)
+    def setup(self, mesh, spin, Ms, Ms_inv):
+        super(TimeZeeman, self).setup(mesh, spin, Ms, Ms_inv)
         self.H_init = self.field.copy()
 
     def compute_field(self, t=0, spin=None):

--- a/tests/test_anis.py
+++ b/tests/test_anis.py
@@ -9,7 +9,8 @@ def test_anis():
     spin = np.zeros(90)
     anis = Anisotropy(Ku=1, axis=[1, 0, 0])
     mu_s = np.ones(90)
-    anis.setup(mesh, spin, mu_s)
+    mu_s_inv = np.ones(90)
+    anis.setup(mesh, spin, mu_s, mu_s_inv)
     field = anis.compute_field()
     assert len(mesh.coordinates) == 5 * 3 * 2
     assert np.max(field) == 0
@@ -22,7 +23,8 @@ def test_anis_cubic():
     spin = np.array([0.6,0.8,0])
     anis = CubicAnisotropy(Kc=1.23)
     mu_s = np.ones(3)
-    anis.setup(mesh, spin, mu_s)
+    mu_s_inv = np.ones(3)
+    anis.setup(mesh, spin, mu_s, mu_s_inv)
     field = anis.compute_field()
     assert  np.max(field-np.array([-1.06272,-2.51904, -0.]))<1e-6
     energy = anis.compute_energy()

--- a/tests/test_check_ms_inv_sensible.py
+++ b/tests/test_check_ms_inv_sensible.py
@@ -1,0 +1,33 @@
+import fidimag
+import numpy as np
+
+def setup_fixture_micro(driver='llg'):
+    mesh = fidimag.common.CuboidMesh(nx=3, ny=3, nz=3,
+                                     dx=1, dy=1, dz=1,
+                                     unit_length=1e-9)
+    sim = fidimag.micro.Sim(mesh, driver=driver)
+    return mesh, sim
+
+
+def setup_fixture_atomistic(driver='llg'):
+    mesh = fidimag.common.CuboidMesh(nx=3, ny=3, nz=3,
+                                     dx=1, dy=1, dz=1,
+                                     unit_length=1e-9)
+    sim = fidimag.atomistic.Sim(mesh, driver=driver)
+    return mesh, sim
+
+def set_Ms(pos):
+    if pos[0] < 2:
+        return 0
+    else:
+        return 5e8
+
+def test_llg_Ms_inv():
+    mesh, sim = setup_fixture_micro()
+    sim.set_Ms(set_Ms)
+    assert np.isnan(np.dot(sim._magnetisation_inv, sim._magnetisation_inv)) == False
+
+def test_llg_atomistic_mu_s_inv():
+    mesh, sim = setup_fixture_atomistic()
+    sim.set_mu_s(set_Ms)
+    assert np.isnan(np.dot(sim._magnetisation_inv, sim._magnetisation_inv)) == False

--- a/tests/test_dw_atomistic.py
+++ b/tests/test_dw_atomistic.py
@@ -30,6 +30,7 @@ def analytical(xs, A=1.3e-11, D=4e-4, K=8e4):
     mz = 1.0 / np.cosh(xs / delta) * np.sin(phi)
     return mx, my, mz
 
+
 def test_dw_dmi_atomistic(do_plot=False):
 
     mesh = CuboidMesh(nx=300, ny=1, nz=1)
@@ -51,7 +52,7 @@ def test_dw_dmi_atomistic(do_plot=False):
     sim.add(dmi)
 
     K = 0.005 * J
-    anis = Anisotropy(K, axis=[1,0,0])
+    anis = Anisotropy(K, axis=[1, 0, 0])
     sim.add(anis)
 
     ONE_DEGREE_PER_NS = 17453292.52

--- a/tests/test_micromagnetic_zeeman.py
+++ b/tests/test_micromagnetic_zeeman.py
@@ -50,6 +50,36 @@ def test_zeeman():
     assert field[7] == 2.3 * 0.5
 
 
+def test_zeeman_energy():
+
+    mu0 = 4 * np.pi * 1e-7
+    # A system of 8 cells ( not using nm units)
+    mesh = CuboidMesh(dx=2, dy=2, dz=2,
+                      nx=2, ny=2, nz=2
+                      )
+
+    sim = Sim(mesh)
+    Ms = 1e5
+    sim.set_Ms(Ms)
+
+    sim.set_m((0, 0, 1))
+
+    H = 0.1 / mu0
+    zeeman = Zeeman((0, 0, H))
+    sim.add(zeeman)
+
+    field = zeeman.compute_field()
+    zf = sim.get_interaction('Zeeman')
+
+    #                             ->    ->
+    # Expected energy: Int ( -mu0 M  *  H  )  dV
+    # Since we have 8 cells with the same M, we just sum their contrib 
+    exp_energy = 8 * (-mu0 * H * Ms * mesh.dx * mesh.dy * mesh.dz)
+
+    assert np.abs(zf.compute_energy() - exp_energy) < 1e-10
+
+
 if __name__ == "__main__":
     test_zeeman()
     test_H0_is_indexable_or_callable()
+    test_zeeman_energy()

--- a/tests/test_regression_referencing.py
+++ b/tests/test_regression_referencing.py
@@ -3,23 +3,14 @@
 
 import fidimag
 
-def setup_fixture_micro():
+def setup_fixture_micro(driver='llg'):
     mesh = fidimag.common.CuboidMesh(nx=10, ny=10, nz=10,
                                      dx=1, dy=1, dz=1,
                                      unit_length=1e-9)
-    sim = fidimag.micro.Sim(mesh)
+    sim = fidimag.micro.Sim(mesh, driver=driver)
     return mesh, sim
 
-
-def setup_fixture_atomistic():
-    mesh = fidimag.common.CuboidMesh(nx=10, ny=10, nz=10,
-                                     dx=1, dy=1, dz=1,
-                                     unit_length=1e-9)
-    sim = fidimag.atomistic.Sim(mesh)
-    return mesh, sim
-
-
-def test_exchange_Ms_regression_micro():
+def test_Ms_regression_Exch_micro():
     mesh, sim = setup_fixture_micro()
     A1 = 2e-11
     Ms1 = 8.5e5
@@ -30,3 +21,170 @@ def test_exchange_Ms_regression_micro():
     sim.set_m(Ms2)
     assert exch.Ms is sim._magnetisation, "The Ms in the Exchange Micro class is not a reference to Ms in the Sim class"
     assert exch.Ms_inv is sim._magnetisation_inv, "The Ms_inv in the Exchange Micro class is not a reference to Ms_inv in the Sim Class"
+
+def test_Ms_regression_Demag_micro():
+    mesh, sim = setup_fixture_micro()
+    Ms1 = 8.5e5
+    Ms2 = 9.0e5
+    sim.set_m(Ms1)
+    demag = fidimag.micro.Demag()
+    sim.add(demag)
+    sim.set_m(Ms2)
+    assert demag.Ms is sim._magnetisation, "The Ms in the Demag Micro class is not a reference to Ms in the Sim class"
+    assert demag.Ms_inv is sim._magnetisation_inv, "The Ms_inv in the Demag Micro class is not a reference to Ms_inv in the Sim Class"
+
+def test_Ms_regression_SimpleDemag_micro():
+    mesh, sim = setup_fixture_micro()
+    Ms1 = 8.5e5
+    Ms2 = 9.0e5
+    sim.set_m(Ms1)
+    demag = fidimag.micro.SimpleDemag()
+    sim.add(demag)
+    sim.set_m(Ms2)
+    assert demag.Ms is sim._magnetisation, "The Ms in the SimpleDemag Micro class is not a reference to Ms in the Sim class"
+    assert demag.Ms_inv is sim._magnetisation_inv, "The Ms_inv in the SimpleDemag Micro class is not a reference to Ms_inv in the Sim Class"
+
+def test_Ms_regression_UniaxialAnisotropy_micro():
+    mesh, sim = setup_fixture_micro()
+    Ku = 2e-11
+    Ms1 = 8.5e5
+    Ms2 = 9.0e5
+    sim.set_Ms(Ms1)
+    anis = fidimag.micro.UniaxialAnisotropy(Ku)
+    sim.add(anis)
+    sim.set_Ms(Ms2)
+    assert anis.Ms is sim._magnetisation, "The Ms in the Exchange Micro class is not a reference to Ms in the Sim class"
+    assert anis.Ms_inv is sim._magnetisation_inv, "The Ms_inv in the UniaxialAnisotropy Micro class is not a reference to Ms_inv in the Sim Class"
+
+def test_exchange_Ms_regression_UniaxialAnisotropy():
+    mesh, sim = setup_fixture_micro()
+    Ku = 2e-11
+    Ms1 = 8.5e5
+    Ms2 = 9.0e5
+    sim.set_Ms(Ms1)
+    anis = fidimag.micro.UniaxialAnisotropy(Ku)
+    sim.add(anis)
+    sim.set_Ms(Ms2)
+    assert anis.Ms is sim._magnetisation, "The Ms in the Exchange Micro class is not a reference to Ms in the Sim class"
+    assert anis.Ms_inv is sim._magnetisation_inv, "The Ms_inv in the UniaxialAnisotropy Micro class is not a reference to Ms_inv in the Sim Class"
+
+def test_llg_Ms_regression():
+    mesh, sim = setup_fixture_micro(driver='llg')
+    Ku = 2e-11
+    Ms1 = 8.5e5
+    Ms2 = 9.0e5
+    sim.set_Ms(Ms1)
+    print(sim.driver._Ms)
+    sim.set_Ms(Ms2)
+    print(sim.driver._Ms)
+    assert sim.driver._Ms is sim._magnetisation
+
+def test_llg_stt_Ms_regression():
+    mesh, sim = setup_fixture_micro(driver='llg_stt')
+    Ku = 2e-11
+    Ms1 = 8.5e5
+    Ms2 = 9.0e5
+    sim.set_Ms(Ms1)
+    print(sim.driver._Ms)
+    sim.set_Ms(Ms2)
+    print(sim.driver._Ms)
+    assert sim.driver._Ms is sim._magnetisation
+
+
+
+
+
+
+
+
+
+
+
+
+
+def setup_fixture_atomistic(driver='llg'):
+    mesh = fidimag.common.CuboidMesh(nx=10, ny=10, nz=10,
+                                     dx=1, dy=1, dz=1,
+                                     unit_length=1e-9)
+    sim = fidimag.atomistic.Sim(mesh, driver=driver)
+    return mesh, sim
+
+def test_Ms_regression_Exch_atom():
+    mesh, sim = setup_fixture_atomistic()
+    A1 = 2e-11
+    Ms1 = 8.5e5
+    Ms2 = 9.0e5
+    sim.set_mu_s(Ms1)
+    exch = fidimag.atomistic.UniformExchange(A1)
+    sim.add(exch)
+    sim.set_mu_s(Ms2)
+    assert exch.mu_s is sim._magnetisation, "The Ms in the Exchange Micro class is not a reference to Ms in the Sim class"
+    assert exch.mu_s_inv is sim._magnetisation_inv, "The Ms_inv in the Exchange Micro class is not a reference to Ms_inv in the Sim Class"
+
+def test_Ms_regression_Demag_atom():
+    mesh, sim = setup_fixture_atomistic()
+    Ms1 = 8.5e5
+    Ms2 = 9.0e5
+    sim.set_mu_s(Ms1)
+    demag = fidimag.atomistic.Demag()
+    sim.add(demag)
+    sim.set_mu_s(Ms2)
+    assert demag.mu_s is sim._magnetisation, "The Ms in the Demag Micro class is not a reference to Ms in the Sim class"
+    assert demag.mu_s_inv is sim._magnetisation_inv, "The Ms_inv in the Demag Micro class is not a reference to Ms_inv in the Sim Class"
+
+def test_Ms_regression_DemagFull_atomistic():
+    mesh, sim = setup_fixture_atomistic()
+    Ms1 = 8.5e5
+    Ms2 = 9.0e5
+    sim.set_mu_s(Ms1)
+    demag = fidimag.atomistic.DemagFull()
+    sim.add(demag)
+    sim.set_mu_s(Ms2)
+    assert demag.mu_s is sim._magnetisation, "The Ms in the SimpleDemag Micro class is not a reference to Ms in the Sim class"
+    assert demag.mu_s_inv is sim._magnetisation_inv, "The Ms_inv in the SimpleDemag Micro class is not a reference to Ms_inv in the Sim Class"
+
+def test_Ms_regression_Anisotropy_atom():
+    mesh, sim = setup_fixture_atomistic()
+    Ku = 2e-11
+    Ms1 = 8.5e5
+    Ms2 = 9.0e5
+    sim.set_mu_s(Ms1)
+    anis = fidimag.atomistic.Anisotropy(Ku)
+    sim.add(anis)
+    sim.set_mu_s(Ms2)
+    assert anis.mu_s is sim._magnetisation, "The Ms in the Exchange atomistic class is not a reference to Ms in the Sim class"
+    assert anis.mu_s_inv is sim._magnetisation_inv, "The mu_s_inv in the Anisotropy atomistic class is not a reference to mu_s_inv in the Sim Class"
+
+def test_exchange_Ms_regression_CubicAnisotropy_atom():
+    mesh, sim = setup_fixture_atomistic()
+    Ku = 2e-11
+    Ms1 = 8.5e5
+    Ms2 = 9.0e5
+    sim.set_mu_s(Ms1)
+    anis = fidimag.atomistic.CubicAnisotropy(Ku)
+    sim.add(anis)
+    sim.set_mu_s(Ms2)
+    assert anis.mu_s is sim._magnetisation, "The Ms in the Exchange atomistic class is not a reference to Ms in the Sim class"
+    assert anis.mu_s_inv is sim._magnetisation_inv, "The mu_s_inv in the CubicAnisotropy atomistic class is not a reference to Ms_inv in the Sim Class"
+
+def test_llg_mu_s_regression_atom():
+    mesh, sim = setup_fixture_atomistic(driver='llg')
+    Ku = 2e-11
+    Ms1 = 8.5e5
+    Ms2 = 9.0e5
+    sim.set_mu_s(Ms1)
+    print(sim.driver._mu_s)
+    sim.set_mu_s(Ms2)
+    print(sim.driver._mu_s)
+    assert sim.driver._mu_s is sim._magnetisation
+
+def test_llg_stt_mu_s_regression_atom():
+    mesh, sim = setup_fixture_atomistic(driver='llg_stt')
+    Ku = 2e-11
+    Ms1 = 8.5e5
+    Ms2 = 9.0e5
+    sim.set_mu_s(Ms1)
+    print(sim.driver._mu_s)
+    sim.set_mu_s(Ms2)
+    print(sim.driver._mu_s)
+    assert sim.driver._mu_s is sim._magnetisation

--- a/tests/test_regression_referencing.py
+++ b/tests/test_regression_referencing.py
@@ -1,0 +1,32 @@
+# The idea behind these tests is to prevent regression back to a bug which was
+# caused by incorrect referencing. This bug caused
+
+import fidimag
+
+def setup_fixture_micro():
+    mesh = fidimag.common.CuboidMesh(nx=10, ny=10, nz=10,
+                                     dx=1, dy=1, dz=1,
+                                     unit_length=1e-9)
+    sim = fidimag.micro.Sim(mesh)
+    return mesh, sim
+
+
+def setup_fixture_atomistic():
+    mesh = fidimag.common.CuboidMesh(nx=10, ny=10, nz=10,
+                                     dx=1, dy=1, dz=1,
+                                     unit_length=1e-9)
+    sim = fidimag.atomistic.Sim(mesh)
+    return mesh, sim
+
+
+def test_exchange_Ms_regression_micro():
+    mesh, sim = setup_fixture_micro()
+    A1 = 2e-11
+    Ms1 = 8.5e5
+    Ms2 = 9.0e5
+    sim.set_m(Ms1)
+    exch = fidimag.micro.UniformExchange(A1)
+    sim.add(exch)
+    sim.set_m(Ms2)
+    assert exch.Ms is sim._magnetisation, "The Ms in the Exchange Micro class is not a reference to Ms in the Sim class"
+    assert exch.Ms_inv is sim._magnetisation_inv, "The Ms_inv in the Exchange Micro class is not a reference to Ms_inv in the Sim Class"

--- a/tests/test_time_zeeman.py
+++ b/tests/test_time_zeeman.py
@@ -12,14 +12,15 @@ def fixture_setup(nx, ny, nz):
     dx = 10.0/nx
     spin = np.zeros(3*nx*ny*nz)
     Ms = np.zeros(nx*ny*nz)
+    Ms_inv = np.zeros(nx*ny*nz)
     mesh = CuboidMesh(nx=nx, ny=ny, nz=nz, dx=dx, dy=1, dz=1, unit_length=1e-9)
     frequency = 10e9
-    return mesh, frequency, spin, Ms
+    return mesh, frequency, spin, Ms, Ms_inv
 
 def test_TimeZeeman():
-    mesh, frequency, spin, Ms = fixture_setup(10, 10, 10)
+    mesh, frequency, spin, Ms, Ms_inv = fixture_setup(10, 10, 10)
     zee = TimeZeeman(np.array([0.0, 0.0, 1.0]), time_fun, extra_args=[frequency])
-    zee.setup(mesh, spin, Ms)
+    zee.setup(mesh, spin, Ms, Ms_inv)
     field1 = zee.compute_field(t=0)
     assert field1[0] == 0
     assert field1[1] == 0


### PR DESCRIPTION
A massive update to the energy and sim classes to avoid problems with the `magnetisation` and `magnetisation_inv` variables, which lose their reference in some classes

The `magnetisation_inv` was carefully tested to pass it as a reference in the energy classes as a `n` array, with `n` the number of cells/atoms of the system. This required to update the field calculations, which are completely computed in the C classes rather than in the Python classes as a Numpy multiplication.

Also fixed the issue in the micromagnetic Zeeman class where, if `Ms` is set after adding the  interactions, the `magnetisation` or `Ms` array was not updated in the energy class, leading to wrong results (horrible bug). The same issue seems to have affected Demag or some other class.  So, we removed any possible variable that might lose reference in the energy class, such as scaling variables and constant arrays (say `Ms_long`)