### PR TITLE
Publication List: Add paper 10.1049/cdt2.12051

### DIFF
--- a/PUBLICATIONS.md
+++ b/PUBLICATIONS.md
@@ -2,6 +2,8 @@
 
 The following publications, in reverse chronological order, have used or cited Fidimag:
 
+[33] [Event-based high throughput computing: A series of case studies on a massively parallel softcore machine](https://doi.org/10.1049/cdt2.12051) IET Computers & Digital Techniques 17(1), 29-42 (2022)
+
 [32] [Thermal Evolution of Skyrmion Formation Mechanism in Chiral Multilayer Films](https://journals.aps.org/prapplied/abstract/10.1103/PhysRevApplied.17.044039) Phys. Rev. Applied 17, 044039 (2022)
 
 [31] [Mutual conversion between a magnetic Néel hopfion and a Néel toron](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.105.174407) Phys. Rev. B 105, 174407 (2022)


### PR DESCRIPTION
Not a pull request in the traditional sense, but a question as to whether or not this paper should be added to fidimag's publication list (I do not want to forcibly merge into a project I have not committed to in almost a decade).

The paper explores an alternative compute architecture for numerical modelling. In the long term, I would like to write a fidimag-adapter so one could export their fidimag simulation to this architecture for deployment. Development is very much ongoing...

The reason I raise the question is because, unlike the other papers in that list, it purely uses Fidimag as a sensible comparator. It is also very much not a paper about magnetism in condensed matter.

Thoughts?